### PR TITLE
Rubocop fixes for mnemonics, ffi

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,6 +24,9 @@ Metrics/LineLength:
 Metrics/MethodLength:
   Max: 80
 
+Metrics/ModuleLength:
+  Max: 500
+
 Metrics/PerceivedComplexity:
   Max: 10
 

--- a/lib/bitcoin/electrum/mnemonic.rb
+++ b/lib/bitcoin/electrum/mnemonic.rb
@@ -1,10 +1,9 @@
 # encoding: ascii-8bit
 
+# ruby version of: https://github.com/spesmilo/electrum/blob/master/lib/mnemonic.py
 class Mnemonic
-  # ruby version of: https://github.com/spesmilo/electrum/blob/master/lib/mnemonic.py
-
   # list of words from http://en.wiktionary.org/wiki/Wiktionary:Frequency_lists/Contemporary_poetry
-  Words = (<<-TEXT).split
+  Words = <<-TEXT.split
     like just love know never want time out there make look eye down only think
     heart back then into about more away still them take thing even through long always
     world too friend tell try hand thought over here other need smile again much cry
@@ -116,47 +115,51 @@ class Mnemonic
     thigh throne total unseen weapon weary
   TEXT
 
-  def self.encode(hex, words=Words)
+  def self.encode(hex, words = Words)
     n = words.size
-    [hex].pack("H*").unpack("N*").map{|x|
+    [hex].pack('H*').unpack('N*').map do |x|
       w1 = x % n
       w2 = ((x / n) + w1) % n
       w3 = ((x / n / n) + w2) % n
-      [ words[w1], words[w2], words[w3] ]
-    }.flatten
+      [words[w1], words[w2], words[w3]]
+    end.flatten
   end
 
-  def self.decode(word_list, words=Words)
+  def self.decode(word_list, words = Words)
     n = words.size
-    word_list.each_slice(3).map{|three_words|
-      w1, w2, w3 = three_words.map{|word| words.index(word) % n }
-      '%08x' % ( w1 + n*((w2-w1)%n) + n*n*((w3-w2)%n) )
-    }.join
+    word_list.each_slice(3).map do |three_words|
+      w1, w2, w3 = three_words.map { |word| words.index(word) % n }
+      format('%08x', (w1 + n * ((w2 - w1) % n) + n * n * ((w3 - w2) % n)))
+    end.join
   end
-
 end
 
+if $PROGRAM_NAME == __FILE__
+  hex = '4c7d10656aa55383a5d88e3f63300af5e169918f4058bf349d99b20239909b61'
+  expected_words = %w[horse love nose speak diamond gaze wash drag glance
+                      money cease soft complete huge aside confusion touch
+                      grass pie play bread exactly bubble great]
 
-
-if $0 == __FILE__
-  hex = "4c7d10656aa55383a5d88e3f63300af5e169918f4058bf349d99b20239909b61"
-  expected_words = ['horse', 'love', 'nose', 'speak', 'diamond', 'gaze', 'wash', 'drag', 'glance',
-                    'money', 'cease', 'soft', 'complete', 'huge', 'aside', 'confusion', 'touch',
-                    'grass', 'pie', 'play', 'bread', 'exactly', 'bubble', 'great']
+  p Mnemonic.encode(hex) == expected_words
+  p Mnemonic.decode(expected_words) == hex
 
   # from http://brainwallet.org/#chains
-  hex = "ff64b72c431f75799f0c5ebe438e46dd"
+  hex = 'ff64b72c431f75799f0c5ebe438e46dd'
   expected_words = %w[muscle lot sea got revenge crack wait yeah gas study embrace spend]
-  hex = "18cfaf96961750c7a4e4e39c861d1415"
+  p Mnemonic.encode(hex) == expected_words
+  p Mnemonic.decode(expected_words) == hex
+
+  hex = '18cfaf96961750c7a4e4e39c861d1415'
   expected_words = %w[example poor twice expect decision master blame rub forward easy jump carve]
+  p Mnemonic.encode(hex) == expected_words
+  p Mnemonic.decode(expected_words) == hex
 
   # from  https://en.bitcoin.it/wiki/Electrum#Brain_Wallet
-  hex = "431a62f1c86555d3c45e5c4d9e10c8c7"
+  hex = '431a62f1c86555d3c45e5c4d9e10c8c7'
   expected_words = %w[constant forest adore false green weave stop guy fur freeze giggle clock]
 
-  #p Mnemonic.encode(hex)
+  # p Mnemonic.encode(hex)
   p Mnemonic.encode(hex) == expected_words
-  #p Mnemonic.decode(expected_words)
+  # p Mnemonic.decode(expected_words)
   p Mnemonic.decode(expected_words) == hex
 end
-

--- a/lib/bitcoin/ffi/openssl.rb
+++ b/lib/bitcoin/ffi/openssl.rb
@@ -1,389 +1,405 @@
 # encoding: ascii-8bit
 
-# autoload when you need to re-generate a public_key from only its private_key.
-# ported from: https://github.com/sipa/bitcoin/blob/2d40fe4da9ea82af4b652b691a4185431d6e47a8/key.h
-
 require 'ffi'
 
 module Bitcoin
-module OpenSSL_EC
-  extend FFI::Library
-  if FFI::Platform.windows?
-    ffi_lib 'libeay32', 'ssleay32'
-  else
-    ffi_lib [ 'libssl.so.1.0.0', 'ssl' ]
-  end
-
-  NID_secp256k1 = 714
-  POINT_CONVERSION_COMPRESSED = 2
-  POINT_CONVERSION_UNCOMPRESSED = 4
-
-  attach_function :SSL_library_init, [], :int
-  attach_function :ERR_load_crypto_strings, [], :void
-  attach_function :SSL_load_error_strings, [], :void
-  attach_function :RAND_poll, [], :int
-
-  attach_function :BN_CTX_free, [:pointer], :int
-  attach_function :BN_CTX_new, [], :pointer
-  attach_function :BN_add, [:pointer, :pointer, :pointer], :int
-  attach_function :BN_bin2bn, [:pointer, :int, :pointer], :pointer
-  attach_function :BN_bn2bin, [:pointer, :pointer], :int
-  attach_function :BN_cmp, [:pointer, :pointer], :int
-  attach_function :BN_copy, [:pointer, :pointer], :pointer
-  attach_function :BN_dup, [:pointer], :pointer
-  attach_function :BN_free, [:pointer], :int
-  attach_function :BN_mod_inverse, [:pointer, :pointer, :pointer, :pointer], :pointer
-  attach_function :BN_mod_mul, [:pointer, :pointer, :pointer, :pointer, :pointer], :int
-  attach_function :BN_mod_sub, [:pointer, :pointer, :pointer, :pointer, :pointer], :int
-  attach_function :BN_mul_word, [:pointer, :int], :int
-  attach_function :BN_new, [], :pointer
-  attach_function :BN_rshift, [:pointer, :pointer, :int], :int
-  attach_function :BN_rshift1, [:pointer, :pointer], :int
-  attach_function :BN_set_word, [:pointer, :int], :int
-  attach_function :BN_sub, [:pointer, :pointer, :pointer], :int
-  attach_function :EC_GROUP_get_curve_GFp, [:pointer, :pointer, :pointer, :pointer, :pointer], :int
-  attach_function :EC_GROUP_get_degree, [:pointer], :int
-  attach_function :EC_GROUP_get_order, [:pointer, :pointer, :pointer], :int
-  attach_function :EC_KEY_free, [:pointer], :int
-  attach_function :EC_KEY_get0_group, [:pointer], :pointer
-  attach_function :EC_KEY_get0_private_key, [:pointer], :pointer
-  attach_function :EC_KEY_new_by_curve_name, [:int], :pointer
-  attach_function :EC_KEY_set_conv_form, [:pointer, :int], :void
-  attach_function :EC_KEY_set_private_key, [:pointer, :pointer], :int
-  attach_function :EC_KEY_set_public_key,  [:pointer, :pointer], :int
-  attach_function :EC_POINT_free, [:pointer], :int
-  attach_function :EC_POINT_is_at_infinity, [:pointer, :pointer], :int
-  attach_function :EC_POINT_mul, [:pointer, :pointer, :pointer, :pointer, :pointer, :pointer], :int
-  attach_function :EC_POINT_new, [:pointer], :pointer
-  attach_function :EC_POINT_set_compressed_coordinates_GFp, [:pointer, :pointer, :pointer, :int, :pointer], :int
-  attach_function :d2i_ECPrivateKey, [:pointer, :pointer, :long], :pointer
-  attach_function :i2d_ECPrivateKey, [:pointer, :pointer], :int
-  attach_function :i2o_ECPublicKey, [:pointer, :pointer], :uint
-  attach_function :EC_KEY_check_key, [:pointer], :uint
-  attach_function :ECDSA_do_sign, [:pointer, :uint, :pointer], :pointer
-  attach_function :BN_num_bits, [:pointer], :int
-  attach_function :ECDSA_SIG_free, [:pointer], :void
-  attach_function :EC_POINT_add, [:pointer, :pointer, :pointer, :pointer, :pointer], :int
-  attach_function :EC_POINT_point2hex, [:pointer, :pointer, :int, :pointer], :string
-  attach_function :EC_POINT_hex2point, [:pointer, :string, :pointer, :pointer], :pointer
-  attach_function :ECDSA_SIG_new, [], :pointer
-  attach_function :d2i_ECDSA_SIG, [:pointer, :pointer, :long], :pointer
-  attach_function :i2d_ECDSA_SIG, [:pointer, :pointer], :int
-  attach_function :OPENSSL_free, :CRYPTO_free, [:pointer], :void
-
-  def self.BN_num_bytes(ptr); (BN_num_bits(ptr) + 7) / 8; end
-
-
-  # resolve public from private key, using ffi and libssl.so
-  # example:
-  #   keypair = Bitcoin.generate_key; Bitcoin::OpenSSL_EC.regenerate_key(keypair.first) == keypair
-  def self.regenerate_key(private_key)
-    private_key = [private_key].pack("H*") if private_key.bytesize >= (32*2)
-    private_key_hex = private_key.unpack("H*")[0]
-
-    #private_key = FFI::MemoryPointer.new(:uint8, private_key.bytesize)
-    #                .put_bytes(0, private_key, 0, private_key.bytesize)
-    private_key = FFI::MemoryPointer.from_string(private_key)
-
-    init_ffi_ssl
-    eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
-    #priv_key = BN_bin2bn(private_key, private_key.size, BN_new())
-    priv_key = BN_bin2bn(private_key, private_key.size-1, BN_new())
-
-    group, order, ctx = EC_KEY_get0_group(eckey), BN_new(), BN_CTX_new()
-    EC_GROUP_get_order(group, order, ctx)
-
-    pub_key = EC_POINT_new(group)
-    EC_POINT_mul(group, pub_key, priv_key, nil, nil, ctx)
-    EC_KEY_set_private_key(eckey, priv_key)
-    EC_KEY_set_public_key(eckey, pub_key)
-
-    BN_free(order)
-    BN_CTX_free(ctx)
-    EC_POINT_free(pub_key)
-    BN_free(priv_key)
-
-
-    length = i2d_ECPrivateKey(eckey, nil)
-    buf = FFI::MemoryPointer.new(:uint8, length)
-    ptr = FFI::MemoryPointer.new(:pointer).put_pointer(0, buf)
-    priv_hex = if i2d_ECPrivateKey(eckey, ptr) == length
-      size = buf.get_array_of_uint8(8, 1)[0]
-      buf.get_array_of_uint8(9, size).pack("C*").rjust(32, "\x00").unpack("H*")[0]
-      #der_to_private_key( ptr.read_pointer.read_string(length).unpack("H*")[0] )
+  # autoload when you need to re-generate a public_key from only its private_key.
+  # ported from: https://github.com/sipa/bitcoin/blob/2d40fe4da9ea82af4b652b691a4185431d6e47a8/key.h
+  module OpenSSL_EC # rubocop:disable Style/ClassAndModuleCamelCase
+    extend FFI::Library
+    if FFI::Platform.windows?
+      ffi_lib 'libeay32', 'ssleay32'
+    else
+      ffi_lib ['libssl.so.1.0.0', 'ssl']
     end
 
-    if priv_hex != private_key_hex
-      raise "regenerated wrong private_key, raise here before generating a faulty public_key too!"
+    NID_secp256k1 = 714 # rubocop:disable Style/ConstantName
+    POINT_CONVERSION_COMPRESSED = 2
+    POINT_CONVERSION_UNCOMPRESSED = 4
+
+    attach_function :SSL_library_init, [], :int
+    attach_function :ERR_load_crypto_strings, [], :void
+    attach_function :SSL_load_error_strings, [], :void
+    attach_function :RAND_poll, [], :int
+
+    attach_function :BN_CTX_free, [:pointer], :int
+    attach_function :BN_CTX_new, [], :pointer
+    attach_function :BN_add, %i[pointer pointer pointer], :int
+    attach_function :BN_bin2bn, %i[pointer int pointer], :pointer
+    attach_function :BN_bn2bin, %i[pointer pointer], :int
+    attach_function :BN_cmp, %i[pointer pointer], :int
+    attach_function :BN_copy, %i[pointer pointer], :pointer
+    attach_function :BN_dup, [:pointer], :pointer
+    attach_function :BN_free, [:pointer], :int
+    attach_function :BN_mod_inverse, %i[pointer pointer pointer pointer], :pointer
+    attach_function :BN_mod_mul, %i[pointer pointer pointer pointer pointer], :int
+    attach_function :BN_mod_sub, %i[pointer pointer pointer pointer pointer], :int
+    attach_function :BN_mul_word, %i[pointer int], :int
+    attach_function :BN_new, [], :pointer
+    attach_function :BN_rshift, %i[pointer pointer int], :int
+    attach_function :BN_rshift1, %i[pointer pointer], :int
+    attach_function :BN_set_word, %i[pointer int], :int
+    attach_function :BN_sub, %i[pointer pointer pointer], :int
+    attach_function :EC_GROUP_get_curve_GFp, %i[pointer pointer pointer pointer pointer], :int
+    attach_function :EC_GROUP_get_degree, [:pointer], :int
+    attach_function :EC_GROUP_get_order, %i[pointer pointer pointer], :int
+    attach_function :EC_KEY_free, [:pointer], :int
+    attach_function :EC_KEY_get0_group, [:pointer], :pointer
+    attach_function :EC_KEY_get0_private_key, [:pointer], :pointer
+    attach_function :EC_KEY_new_by_curve_name, [:int], :pointer
+    attach_function :EC_KEY_set_conv_form, %i[pointer int], :void
+    attach_function :EC_KEY_set_private_key, %i[pointer pointer], :int
+    attach_function :EC_KEY_set_public_key,  %i[pointer pointer], :int
+    attach_function :EC_POINT_free, [:pointer], :int
+    attach_function :EC_POINT_is_at_infinity, %i[pointer pointer], :int
+    attach_function :EC_POINT_mul, %i[pointer pointer pointer pointer pointer pointer], :int
+    attach_function :EC_POINT_new, [:pointer], :pointer
+    attach_function :EC_POINT_set_compressed_coordinates_GFp,
+                    %i[pointer pointer pointer int pointer], :int
+    attach_function :d2i_ECPrivateKey, %i[pointer pointer long], :pointer
+    attach_function :i2d_ECPrivateKey, %i[pointer pointer], :int
+    attach_function :i2o_ECPublicKey, %i[pointer pointer], :uint
+    attach_function :EC_KEY_check_key, [:pointer], :uint
+    attach_function :ECDSA_do_sign, %i[pointer uint pointer], :pointer
+    attach_function :BN_num_bits, [:pointer], :int
+    attach_function :ECDSA_SIG_free, [:pointer], :void
+    attach_function :EC_POINT_add, %i[pointer pointer pointer pointer pointer], :int
+    attach_function :EC_POINT_point2hex, %i[pointer pointer int pointer], :string
+    attach_function :EC_POINT_hex2point, %i[pointer string pointer pointer], :pointer
+    attach_function :ECDSA_SIG_new, [], :pointer
+    attach_function :d2i_ECDSA_SIG, %i[pointer pointer long], :pointer
+    attach_function :i2d_ECDSA_SIG, %i[pointer pointer], :int
+    attach_function :OPENSSL_free, :CRYPTO_free, [:pointer], :void
+
+    def self.BN_num_bytes(ptr) # rubocop:disable Style/MethodName
+      (BN_num_bits(ptr) + 7) / 8
     end
 
+    # resolve public from private key, using ffi and libssl.so
+    # example:
+    #   keypair = Bitcoin.generate_key; Bitcoin::OpenSSL_EC.regenerate_key(keypair.first) == keypair
+    def self.regenerate_key(private_key)
+      private_key = [private_key].pack('H*') if private_key.bytesize >= (32 * 2)
+      private_key_hex = private_key.unpack('H*')[0]
 
-    length = i2o_ECPublicKey(eckey, nil)
-    buf = FFI::MemoryPointer.new(:uint8, length)
-    ptr = FFI::MemoryPointer.new(:pointer).put_pointer(0, buf)
-    pub_hex = if i2o_ECPublicKey(eckey, ptr) == length
-      buf.read_string(length).unpack("H*")[0]
-    end
+      # private_key = FFI::MemoryPointer.new(:uint8, private_key.bytesize)
+      #                .put_bytes(0, private_key, 0, private_key.bytesize)
+      private_key = FFI::MemoryPointer.from_string(private_key)
 
-    EC_KEY_free(eckey)
+      init_ffi_ssl
+      eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
+      # priv_key = BN_bin2bn(private_key, private_key.size, BN_new())
+      priv_key = BN_bin2bn(private_key, private_key.size - 1, BN_new())
 
-    [ priv_hex, pub_hex ]
-  end
+      group = EC_KEY_get0_group(eckey)
+      order = BN_new()
+      ctx = BN_CTX_new()
+      EC_GROUP_get_order(group, order, ctx)
 
-  # extract private key from uncompressed DER format
-  def self.der_to_private_key(der_hex)
-    init_ffi_ssl
-    #k  = EC_KEY_new_by_curve_name(NID_secp256k1)
-    #kp = FFI::MemoryPointer.new(:pointer).put_pointer(0, eckey)
+      pub_key = EC_POINT_new(group)
+      EC_POINT_mul(group, pub_key, priv_key, nil, nil, ctx)
+      EC_KEY_set_private_key(eckey, priv_key)
+      EC_KEY_set_public_key(eckey, pub_key)
 
-    buf = FFI::MemoryPointer.from_string([der_hex].pack("H*"))
-    ptr = FFI::MemoryPointer.new(:pointer).put_pointer(0, buf)
+      BN_free(order)
+      BN_CTX_free(ctx)
+      EC_POINT_free(pub_key)
+      BN_free(priv_key)
 
-    #ec_key = d2i_ECPrivateKey(kp, ptr, buf.size-1)
-    ec_key = d2i_ECPrivateKey(nil, ptr, buf.size-1)
-    return nil if ec_key.null?
-    bn = EC_KEY_get0_private_key(ec_key)
-    BN_bn2bin(bn, buf)
-    buf.read_string(32).unpack("H*")[0]
-  end
+      length = i2d_ECPrivateKey(eckey, nil)
+      buf = FFI::MemoryPointer.new(:uint8, length)
+      ptr = FFI::MemoryPointer.new(:pointer).put_pointer(0, buf)
+      priv_hex = if i2d_ECPrivateKey(eckey, ptr) == length
+                   size = buf.get_array_of_uint8(8, 1)[0]
+                   buf.get_array_of_uint8(9, size).pack('C*').rjust(32, "\x00").unpack('H*')[0]
+                   # der_to_private_key( ptr.read_pointer.read_string(length).unpack("H*")[0] )
+                 end
 
-  # Given the components of a signature and a selector value, recover and
-  # return the public key that generated the signature according to the
-  # algorithm in SEC1v2 section 4.1.6.
-  #
-  # rec_id is an index from 0 to 3 that indicates which of the 4 possible
-  # keys is the correct one. Because the key recovery operation yields
-  # multiple potential keys, the correct key must either be stored alongside
-  # the signature, or you must be willing to try each rec_id in turn until
-  # you find one that outputs the key you are expecting.
-  #
-  # If this method returns nil, it means recovery was not possible and rec_id
-  # should be iterated.
-  #
-  # Given the above two points, a correct usage of this method is inside a
-  # for loop from 0 to 3, and if the output is nil OR a key that is not the
-  # one you expect, you try again with the next rec_id.
-  #
-  #   message_hash = hash of the signed message.
-  #   signature = the R and S components of the signature, wrapped.
-  #   rec_id = which possible key to recover.
-  #   is_compressed = whether or not the original pubkey was compressed.
-  def self.recover_public_key_from_signature(message_hash, signature, rec_id, is_compressed)
-    return nil if rec_id < 0 or signature.bytesize != 65
-    init_ffi_ssl
+      if priv_hex != private_key_hex
+        raise 'regenerated wrong private_key, raise here before generating a faulty public_key too!'
+      end
 
-    signature = FFI::MemoryPointer.from_string(signature)
-    #signature_bn = BN_bin2bn(signature, 65, BN_new())
-    r = BN_bin2bn(signature[1], 32, BN_new())
-    s = BN_bin2bn(signature[33], 32, BN_new())
+      length = i2o_ECPublicKey(eckey, nil)
+      buf = FFI::MemoryPointer.new(:uint8, length)
+      ptr = FFI::MemoryPointer.new(:pointer).put_pointer(0, buf)
+      pub_hex = buf.read_string(length).unpack('H*')[0] if i2o_ECPublicKey(eckey, ptr) == length
 
-    n, i = 0, rec_id / 2
-    eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
-
-    EC_KEY_set_conv_form(eckey, POINT_CONVERSION_COMPRESSED) if is_compressed
-
-    group = EC_KEY_get0_group(eckey)
-    order = BN_new()
-    EC_GROUP_get_order(group, order, nil)
-    x = BN_dup(order)
-    BN_mul_word(x, i)
-    BN_add(x, x, r)
-
-    field = BN_new()
-    EC_GROUP_get_curve_GFp(group, field, nil, nil, nil)
-
-    if BN_cmp(x, field) >= 0
-      [r, s, order, x, field].each{|item| BN_free(item) }
       EC_KEY_free(eckey)
-      return nil
+
+      [priv_hex, pub_hex]
     end
 
-    big_r = EC_POINT_new(group)
-    EC_POINT_set_compressed_coordinates_GFp(group, big_r, x, rec_id % 2, nil)
+    # extract private key from uncompressed DER format
+    def self.der_to_private_key(der_hex)
+      init_ffi_ssl
+      # k  = EC_KEY_new_by_curve_name(NID_secp256k1)
+      # kp = FFI::MemoryPointer.new(:pointer).put_pointer(0, eckey)
 
-    big_q = EC_POINT_new(group)
-    n = EC_GROUP_get_degree(group)
-    e = BN_bin2bn(message_hash, message_hash.bytesize, BN_new())
-    BN_rshift(e, e, 8 - (n & 7)) if 8 * message_hash.bytesize > n
+      buf = FFI::MemoryPointer.from_string([der_hex].pack('H*'))
+      ptr = FFI::MemoryPointer.new(:pointer).put_pointer(0, buf)
 
-    ctx = BN_CTX_new()
-    zero, rr, sor, eor = BN_new(), BN_new(), BN_new(), BN_new()
-    BN_set_word(zero, 0)
-    BN_mod_sub(e, zero, e, order, ctx)
-    BN_mod_inverse(rr, r, order, ctx)
-    BN_mod_mul(sor, s, rr, order, ctx)
-    BN_mod_mul(eor, e, rr, order, ctx)
-    EC_POINT_mul(group, big_q, eor, big_r, sor, ctx)
-    EC_KEY_set_public_key(eckey, big_q)
-    BN_CTX_free(ctx)
-
-    [r, s, order, x, field, e, zero, rr, sor, eor].each{|item| BN_free(item) }
-    [big_r, big_q].each{|item| EC_POINT_free(item) }
-
-    length = i2o_ECPublicKey(eckey, nil)
-    buf = FFI::MemoryPointer.new(:uint8, length)
-    ptr = FFI::MemoryPointer.new(:pointer).put_pointer(0, buf)
-    pub_hex = if i2o_ECPublicKey(eckey, ptr) == length
-      buf.read_string(length).unpack("H*")[0]
+      # ec_key = d2i_ECPrivateKey(kp, ptr, buf.size-1)
+      ec_key = d2i_ECPrivateKey(nil, ptr, buf.size - 1)
+      return nil if ec_key.null?
+      bn = EC_KEY_get0_private_key(ec_key)
+      BN_bn2bin(bn, buf)
+      buf.read_string(32).unpack('H*')[0]
     end
 
-    EC_KEY_free(eckey)
+    # Given the components of a signature and a selector value, recover and
+    # return the public key that generated the signature according to the
+    # algorithm in SEC1v2 section 4.1.6.
+    #
+    # rec_id is an index from 0 to 3 that indicates which of the 4 possible
+    # keys is the correct one. Because the key recovery operation yields
+    # multiple potential keys, the correct key must either be stored alongside
+    # the signature, or you must be willing to try each rec_id in turn until
+    # you find one that outputs the key you are expecting.
+    #
+    # If this method returns nil, it means recovery was not possible and rec_id
+    # should be iterated.
+    #
+    # Given the above two points, a correct usage of this method is inside a
+    # for loop from 0 to 3, and if the output is nil OR a key that is not the
+    # one you expect, you try again with the next rec_id.
+    #
+    #   message_hash = hash of the signed message.
+    #   signature = the R and S components of the signature, wrapped.
+    #   rec_id = which possible key to recover.
+    #   is_compressed = whether or not the original pubkey was compressed.
+    def self.recover_public_key_from_signature(message_hash, signature, rec_id, is_compressed)
+      return nil if rec_id < 0 || signature.bytesize != 65
+      init_ffi_ssl
 
-    pub_hex
-  end
+      signature = FFI::MemoryPointer.from_string(signature)
+      # signature_bn = BN_bin2bn(signature, 65, BN_new())
+      r = BN_bin2bn(signature[1], 32, BN_new())
+      s = BN_bin2bn(signature[33], 32, BN_new())
 
-  # Regenerate a DER-encoded signature such that the S-value complies with the BIP62
-  # specification.
-  #
-  def self.signature_to_low_s(signature)
-    init_ffi_ssl
+      i = rec_id / 2
+      eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
 
-    buf = FFI::MemoryPointer.new(:uint8, 34)
-    temp = signature.unpack("C*")
-    length_r = temp[3]
-    length_s = temp[5+length_r]
-    sig = FFI::MemoryPointer.from_string(signature)
+      EC_KEY_set_conv_form(eckey, POINT_CONVERSION_COMPRESSED) if is_compressed
 
-    # Calculate the lower s value
-    s = BN_bin2bn(sig[6 + length_r], length_s, BN_new())
-    eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
-    group, order, halforder, ctx = EC_KEY_get0_group(eckey), BN_new(), BN_new(), BN_CTX_new()
+      group = EC_KEY_get0_group(eckey)
+      order = BN_new()
+      EC_GROUP_get_order(group, order, nil)
+      x = BN_dup(order)
+      BN_mul_word(x, i)
+      BN_add(x, x, r)
 
-    EC_GROUP_get_order(group, order, ctx)
-    BN_rshift1(halforder, order)
-    if BN_cmp(s, halforder) > 0
-      BN_sub(s, order, s)
+      field = BN_new()
+      EC_GROUP_get_curve_GFp(group, field, nil, nil, nil)
+
+      if BN_cmp(x, field) >= 0
+        [r, s, order, x, field].each { |item| BN_free(item) }
+        EC_KEY_free(eckey)
+        return nil
+      end
+
+      big_r = EC_POINT_new(group)
+      EC_POINT_set_compressed_coordinates_GFp(group, big_r, x, rec_id % 2, nil)
+
+      big_q = EC_POINT_new(group)
+      n = EC_GROUP_get_degree(group)
+      e = BN_bin2bn(message_hash, message_hash.bytesize, BN_new())
+      BN_rshift(e, e, 8 - (n & 7)) if 8 * message_hash.bytesize > n
+
+      ctx = BN_CTX_new()
+      zero = BN_new()
+      rr = BN_new()
+      sor = BN_new()
+      eor = BN_new()
+      BN_set_word(zero, 0)
+      BN_mod_sub(e, zero, e, order, ctx)
+      BN_mod_inverse(rr, r, order, ctx)
+      BN_mod_mul(sor, s, rr, order, ctx)
+      BN_mod_mul(eor, e, rr, order, ctx)
+      EC_POINT_mul(group, big_q, eor, big_r, sor, ctx)
+      EC_KEY_set_public_key(eckey, big_q)
+      BN_CTX_free(ctx)
+
+      [r, s, order, x, field, e, zero, rr, sor, eor].each { |item| BN_free(item) }
+      [big_r, big_q].each { |item| EC_POINT_free(item) }
+
+      length = i2o_ECPublicKey(eckey, nil)
+      buf = FFI::MemoryPointer.new(:uint8, length)
+      ptr = FFI::MemoryPointer.new(:pointer).put_pointer(0, buf)
+      pub_hex = buf.read_string(length).unpack('H*')[0] if i2o_ECPublicKey(eckey, ptr) == length
+
+      EC_KEY_free(eckey)
+
+      pub_hex
     end
 
-    BN_free(halforder)
-    BN_free(order)
-    BN_CTX_free(ctx)
+    # Regenerate a DER-encoded signature such that the S-value complies with the BIP62
+    # specification.
+    #
+    def self.signature_to_low_s(signature)
+      init_ffi_ssl
 
-    length_s = BN_bn2bin(s, buf)
-    # p buf.read_string(length_s).unpack("H*")
+      buf = FFI::MemoryPointer.new(:uint8, 34)
+      temp = signature.unpack('C*')
+      length_r = temp[3]
+      length_s = temp[5 + length_r]
+      sig = FFI::MemoryPointer.from_string(signature)
 
-    # Re-encode the signature in DER format
-    sig = [0x30, 0, 0x02, length_r]
-    sig.concat(temp.slice(4, length_r))
-    sig << 0x02
-    sig << length_s
-    sig.concat(buf.read_string(length_s).unpack("C*"))
-    sig[1] = sig.size - 2
+      # Calculate the lower s value
+      s = BN_bin2bn(sig[6 + length_r], length_s, BN_new())
+      eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
+      group = EC_KEY_get0_group(eckey)
+      order = BN_new()
+      halforder = BN_new()
+      ctx = BN_CTX_new()
 
-    BN_free(s)
-    EC_KEY_free(eckey)
+      EC_GROUP_get_order(group, order, ctx)
+      BN_rshift1(halforder, order)
+      BN_sub(s, order, s) if BN_cmp(s, halforder) > 0
 
-    sig.pack("C*")
-  end
+      BN_free(halforder)
+      BN_free(order)
+      BN_CTX_free(ctx)
 
-  def self.sign_compact(hash, private_key, public_key_hex = nil, pubkey_compressed = nil)
-    msg32 = FFI::MemoryPointer.new(:uchar, 32).put_bytes(0, hash)
+      length_s = BN_bn2bin(s, buf)
+      # p buf.read_string(length_s).unpack("H*")
 
-    private_key = [private_key].pack("H*") if private_key.bytesize >= 64
-    private_key_hex = private_key.unpack("H*")[0]
+      # Re-encode the signature in DER format
+      sig = [0x30, 0, 0x02, length_r]
+      sig.concat(temp.slice(4, length_r))
+      sig << 0x02
+      sig << length_s
+      sig.concat(buf.read_string(length_s).unpack('C*'))
+      sig[1] = sig.size - 2
 
-    public_key_hex = regenerate_key(private_key_hex).last unless public_key_hex
-    pubkey_compressed = (public_key_hex[0..1] == "04" ? false : true) unless pubkey_compressed
+      BN_free(s)
+      EC_KEY_free(eckey)
 
-    init_ffi_ssl
-    eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
-    priv_key = BN_bin2bn(private_key, private_key.bytesize, BN_new())
+      sig.pack('C*')
+    end
 
-    group, order, ctx = EC_KEY_get0_group(eckey), BN_new(), BN_CTX_new()
-    EC_GROUP_get_order(group, order, ctx)
+    def self.sign_compact(hash, private_key, public_key_hex = nil, pubkey_compressed = nil)
+      msg32 = FFI::MemoryPointer.new(:uchar, 32).put_bytes(0, hash)
 
-    pub_key = EC_POINT_new(group)
-    EC_POINT_mul(group, pub_key, priv_key, nil, nil, ctx)
-    EC_KEY_set_private_key(eckey, priv_key)
-    EC_KEY_set_public_key(eckey, pub_key)
+      private_key = [private_key].pack('H*') if private_key.bytesize >= 64
+      private_key_hex = private_key.unpack('H*')[0]
 
-    signature = ECDSA_do_sign(msg32, msg32.size, eckey)
+      public_key_hex ||= regenerate_key(private_key_hex).last
+      pubkey_compressed ||= public_key_hex[0..1] != '04'
 
-    BN_free(order)
-    BN_CTX_free(ctx)
-    EC_POINT_free(pub_key)
-    BN_free(priv_key)
-    EC_KEY_free(eckey)
+      init_ffi_ssl
+      eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
+      priv_key = BN_bin2bn(private_key, private_key.bytesize, BN_new())
 
-    buf, rec_id, head = FFI::MemoryPointer.new(:uint8, 32), nil, nil
-    r, s = signature.get_array_of_pointer(0, 2).map{|i| BN_bn2bin(i, buf); buf.read_string(BN_num_bytes(i)).rjust(32, "\x00") }
+      group = EC_KEY_get0_group(eckey)
+      order = BN_new()
+      ctx = BN_CTX_new()
+      EC_GROUP_get_order(group, order, ctx)
 
-    if signature.get_array_of_pointer(0, 2).all?{|i| BN_num_bits(i) <= 256 }
-      4.times{|i|
-        head = [ 27 + i + (pubkey_compressed ? 4 : 0) ].pack("C")
-        if public_key_hex == recover_public_key_from_signature(msg32.read_string(32), [head, r, s].join, i, pubkey_compressed)
-          rec_id = i; break
+      pub_key = EC_POINT_new(group)
+      EC_POINT_mul(group, pub_key, priv_key, nil, nil, ctx)
+      EC_KEY_set_private_key(eckey, priv_key)
+      EC_KEY_set_public_key(eckey, pub_key)
+
+      signature = ECDSA_do_sign(msg32, msg32.size, eckey)
+
+      BN_free(order)
+      BN_CTX_free(ctx)
+      EC_POINT_free(pub_key)
+      BN_free(priv_key)
+      EC_KEY_free(eckey)
+
+      buf = FFI::MemoryPointer.new(:uint8, 32)
+      head = nil
+      r, s = signature.get_array_of_pointer(0, 2).map do |i|
+        BN_bn2bin(i, buf)
+        buf.read_string(BN_num_bytes(i)).rjust(32, "\x00")
+      end
+
+      rec_id = nil
+      if signature.get_array_of_pointer(0, 2).all? { |i| BN_num_bits(i) <= 256 }
+        4.times do |i|
+          head = [27 + i + (pubkey_compressed ? 4 : 0)].pack('C')
+          recovered_key = recover_public_key_from_signature(
+            msg32.read_string(32), [head, r, s].join, i, pubkey_compressed
+          )
+          if public_key_hex == recovered_key
+            rec_id = i
+            break
+          end
         end
-      }
+      end
+
+      ECDSA_SIG_free(signature)
+
+      [head, [r, s]].join if rec_id
     end
 
-    ECDSA_SIG_free(signature)
+    def self.recover_compact(hash, signature)
+      return false if signature.bytesize != 65
+      msg32 = FFI::MemoryPointer.new(:uchar, 32).put_bytes(0, hash)
 
-    [ head, [r,s] ].join if rec_id
+      version = signature.unpack('C')[0]
+      return false if version < 27 || version > 34
+
+      compressed = version >= 31
+      version -= 4 if compressed
+
+      recover_public_key_from_signature(msg32.read_string(32), signature, version - 27, compressed)
+    end
+
+    # lifted from https://github.com/GemHQ/money-tree
+    def self.ec_add(point0, point1)
+      init_ffi_ssl
+
+      eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
+      group = EC_KEY_get0_group(eckey)
+
+      point_0_hex = point0.to_bn.to_s(16)
+      point_0_pt = EC_POINT_hex2point(group, point_0_hex, nil, nil)
+      point_1_hex = point1.to_bn.to_s(16)
+      point_1_pt = EC_POINT_hex2point(group, point_1_hex, nil, nil)
+
+      sum_point = EC_POINT_new(group)
+      EC_POINT_add(group, sum_point, point_0_pt, point_1_pt, nil)
+      hex = EC_POINT_point2hex(group, sum_point, POINT_CONVERSION_UNCOMPRESSED, nil)
+      EC_KEY_free(eckey)
+      EC_POINT_free(sum_point)
+      hex
+    end
+
+    # repack signature for OpenSSL 1.0.1k handling of DER signatures
+    # https://github.com/bitcoin/bitcoin/pull/5634/files
+    def self.repack_der_signature(signature)
+      init_ffi_ssl
+
+      return false if signature.empty?
+
+      # New versions of OpenSSL will reject non-canonical DER signatures. de/re-serialize first.
+      norm_der = FFI::MemoryPointer.new(:pointer)
+      sig_ptr  = FFI::MemoryPointer.new(:pointer).put_pointer(
+        0, FFI::MemoryPointer.from_string(signature)
+      )
+
+      norm_sig = d2i_ECDSA_SIG(nil, sig_ptr, signature.bytesize)
+
+      derlen = i2d_ECDSA_SIG(norm_sig, norm_der)
+      ECDSA_SIG_free(norm_sig)
+      return false if derlen <= 0
+
+      ret = norm_der.read_pointer.read_string(derlen)
+      OPENSSL_free(norm_der.read_pointer)
+
+      ret
+    end
+
+    def self.init_ffi_ssl
+      @ssl_loaded ||= false
+      return if @ssl_loaded
+      SSL_library_init()
+      ERR_load_crypto_strings()
+      SSL_load_error_strings()
+      RAND_poll()
+      @ssl_loaded = true
+    end
   end
-
-  def self.recover_compact(hash, signature)
-    return false if signature.bytesize != 65
-    msg32 = FFI::MemoryPointer.new(:uchar, 32).put_bytes(0, hash)
-
-    version = signature.unpack('C')[0]
-    return false if version < 27 or version > 34
-
-    compressed = (version >= 31) ? (version -= 4; true) : false
-    recover_public_key_from_signature(msg32.read_string(32), signature, version-27, compressed)
-  end
-
-  # lifted from https://github.com/GemHQ/money-tree
-  def self.ec_add(point_0, point_1)
-    init_ffi_ssl
-
-    eckey = EC_KEY_new_by_curve_name(NID_secp256k1)
-    group = EC_KEY_get0_group(eckey)
-
-    point_0_hex = point_0.to_bn.to_s(16)
-    point_0_pt = EC_POINT_hex2point(group, point_0_hex, nil, nil)
-    point_1_hex = point_1.to_bn.to_s(16)
-    point_1_pt = EC_POINT_hex2point(group, point_1_hex, nil, nil)
-
-    sum_point = EC_POINT_new(group)
-    EC_POINT_add(group, sum_point, point_0_pt, point_1_pt, nil)
-    hex = EC_POINT_point2hex(group, sum_point, POINT_CONVERSION_UNCOMPRESSED, nil)
-    EC_KEY_free(eckey)
-    EC_POINT_free(sum_point)
-    hex
-  end
-
-  # repack signature for OpenSSL 1.0.1k handling of DER signatures
-  # https://github.com/bitcoin/bitcoin/pull/5634/files
-  def self.repack_der_signature(signature)
-    init_ffi_ssl
-
-    return false if signature.empty?
-
-    # New versions of OpenSSL will reject non-canonical DER signatures. de/re-serialize first.
-    norm_der = FFI::MemoryPointer.new(:pointer)
-    sig_ptr  = FFI::MemoryPointer.new(:pointer).put_pointer(0, FFI::MemoryPointer.from_string(signature))
-
-    norm_sig = d2i_ECDSA_SIG(nil, sig_ptr, signature.bytesize)
-
-    derlen = i2d_ECDSA_SIG(norm_sig, norm_der)
-    ECDSA_SIG_free(norm_sig)
-    return false if derlen <= 0
-
-    ret = norm_der.read_pointer.read_string(derlen)
-    OPENSSL_free(norm_der.read_pointer)
-
-    ret
-  end
-
-  def self.init_ffi_ssl
-    @ssl_loaded ||= false
-    return if @ssl_loaded
-    SSL_library_init()
-    ERR_load_crypto_strings()
-    SSL_load_error_strings()
-    RAND_poll()
-    @ssl_loaded = true
-  end
-end
 end

--- a/lib/bitcoin/trezor/mnemonic.rb
+++ b/lib/bitcoin/trezor/mnemonic.rb
@@ -1,5 +1,4 @@
 # encoding: ascii-8bit
-# port of https://github.com/trezor/python-mnemonic/blob/master/mnemonic/mnemonic.py
 
 require 'openssl'
 require 'securerandom'
@@ -7,125 +6,137 @@ require 'digest'
 
 module Bitcoin
   module Trezor
-
+    # port of https://github.com/trezor/python-mnemonic/blob/master/mnemonic/mnemonic.py
     module Mnemonic
-      def self.to_seed(mnemonic, passphrase='')
-        OpenSSL::PKCS5.pbkdf2_hmac(mnemonic, 'mnemonic'+passphrase, 2048, 64, OpenSSL::Digest::SHA512.new).unpack("H*")[0]
+      def self.to_seed(mnemonic, passphrase = '')
+        OpenSSL::PKCS5.pbkdf2_hmac(
+          mnemonic, 'mnemonic' + passphrase, 2048, 64, OpenSSL::Digest::SHA512.new
+        ).unpack('H*')[0]
       end
 
       def self.generate(strength_bits = 256)
-        raise ArgumentError, 'Strength should be divisible by 32, but it is not (%d)' % [strength_bits] if (strength_bits % 32) > 0
-        data = SecureRandom.random_bytes( (strength_bits / 8).floor )
+        if (strength_bits % 32) > 0
+          raise ArgumentError, format(
+            'Strength should be divisible by 32, but it is not (%d)', strength_bits
+          )
+        end
+        data = SecureRandom.random_bytes((strength_bits / 8).floor)
         to_mnemonic(data)
       end
 
       def self.wordlist
         @wordlist ||= nil
         return @wordlist if @wordlist
-        @wordlist = WORDLIST_ENGLISH.split(/[ \n]/).map{|i| i.strip }
-        if @wordlist.size != (radix=2048)
-          raise ArgumentError, 'Wordlist should contain %d words, but it contains %d words.' % [radix, wordlist.size]
+        @wordlist = WORDLIST_ENGLISH.split(/[ \n]/).map(&:strip)
+        if @wordlist.size != (radix = 2048)
+          raise ArgumentError, format(
+            'Wordlist should contain %d words, but it contains %d words.', radix, wordlist.size
+          )
         end
         @wordlist
       end
 
       def self.to_mnemonic(data)
         if (data.bytesize % 4) > 0
-          raise ArgumentError, 'Data length in bits should be divisible by 32, but it is not (%d bytes = %d bits).' % [data.bytesize, data.bytesize * 8]
+          raise ArgumentError, format(
+            'Data length in bits should be divisible by 32, ' \
+            'but it is not (%d bytes = %d bits).', data.bytesize, data.bytesize * 8
+          )
         end
-        b = data.unpack("B*")[0] + Digest::SHA256.digest(data).unpack("B*")[0].ljust(256, '0')[0...(data.bytesize * 8 / 32)]
+        b = data.unpack('B*')[0] +
+            Digest::SHA256.digest(data).unpack('B*')[0]
+                          .ljust(256, '0')[0...(data.bytesize * 8 / 32)]
 
-        (0...(b.bytesize / 11)).map{|i|
-          idx = b[ (i * 11)...((i+1) * 11) ].to_i(2)
+        (0...(b.bytesize / 11)).map do |i|
+          idx = b[(i * 11)...((i + 1) * 11)].to_i(2)
           wordlist[idx]
-        }.join(" ")
+        end.join(' ')
       end
 
-      WORDLIST_ENGLISH = <<-TEXT
-abandon ability able about above absent absorb abstract absurd abuse access accident account accuse achieve acid acoustic acquire across act action actor actress actual adapt
-add addict address adjust admit adult advance advice aerobic affair afford afraid again age agent agree ahead aim air airport aisle alarm album alcohol alert
-alien all alley allow almost alone alpha already also alter always amateur amazing among amount amused analyst anchor ancient anger angle angry animal ankle announce
-annual another answer antenna antique anxiety any apart apology appear apple approve april arch arctic area arena argue arm armed armor army around arrange arrest
-arrive arrow art artefact artist artwork ask aspect assault asset assist assume asthma athlete atom attack attend attitude attract auction audit august aunt author auto
-autumn average avocado avoid awake aware away awesome awful awkward axis baby bachelor bacon badge bag balance balcony ball bamboo banana banner bar barely bargain
-barrel base basic basket battle beach bean beauty because become beef before begin behave behind believe below belt bench benefit best betray better between beyond
-bicycle bid bike bind biology bird birth bitter black blade blame blanket blast bleak bless blind blood blossom blouse blue blur blush board boat body
-boil bomb bone bonus book boost border boring borrow boss bottom bounce box boy bracket brain brand brass brave bread breeze brick bridge brief bright
-bring brisk broccoli broken bronze broom brother brown brush bubble buddy budget buffalo build bulb bulk bullet bundle bunker burden burger burst bus business busy
-butter buyer buzz cabbage cabin cable cactus cage cake call calm camera camp can canal cancel candy cannon canoe canvas canyon capable capital captain car
-carbon card cargo carpet carry cart case cash casino castle casual cat catalog catch category cattle caught cause caution cave ceiling celery cement census century
-cereal certain chair chalk champion change chaos chapter charge chase chat cheap check cheese chef cherry chest chicken chief child chimney choice choose chronic chuckle
-chunk churn cigar cinnamon circle citizen city civil claim clap clarify claw clay clean clerk clever click client cliff climb clinic clip clock clog close
-cloth cloud clown club clump cluster clutch coach coast coconut code coffee coil coin collect color column combine come comfort comic common company concert conduct
-confirm congress connect consider control convince cook cool copper copy coral core corn correct cost cotton couch country couple course cousin cover coyote crack cradle
-craft cram crane crash crater crawl crazy cream credit creek crew cricket crime crisp critic crop cross crouch crowd crucial cruel cruise crumble crunch crush
-cry crystal cube culture cup cupboard curious current curtain curve cushion custom cute cycle dad damage damp dance danger daring dash daughter dawn day deal
-debate debris decade december decide decline decorate decrease deer defense define defy degree delay deliver demand demise denial dentist deny depart depend deposit depth deputy
-derive describe desert design desk despair destroy detail detect develop device devote diagram dial diamond diary dice diesel diet differ digital dignity dilemma dinner dinosaur
-direct dirt disagree discover disease dish dismiss disorder display distance divert divide divorce dizzy doctor document dog doll dolphin domain donate donkey donor door dose
-double dove draft dragon drama drastic draw dream dress drift drill drink drip drive drop drum dry duck dumb dune during dust dutch duty dwarf
-dynamic eager eagle early earn earth easily east easy echo ecology economy edge edit educate effort egg eight either elbow elder electric elegant element elephant
-elevator elite else embark embody embrace emerge emotion employ empower empty enable enact end endless endorse enemy energy enforce engage engine enhance enjoy enlist enough
-enrich enroll ensure enter entire entry envelope episode equal equip era erase erode erosion error erupt escape essay essence estate eternal ethics evidence evil evoke
-evolve exact example excess exchange excite exclude excuse execute exercise exhaust exhibit exile exist exit exotic expand expect expire explain expose express extend extra eye
-eyebrow fabric face faculty fade faint faith fall false fame family famous fan fancy fantasy farm fashion fat fatal father fatigue fault favorite feature february
-federal fee feed feel female fence festival fetch fever few fiber fiction field figure file film filter final find fine finger finish fire firm first
-fiscal fish fit fitness fix flag flame flash flat flavor flee flight flip float flock floor flower fluid flush fly foam focus fog foil fold
-follow food foot force forest forget fork fortune forum forward fossil foster found fox fragile frame frequent fresh friend fringe frog front frost frown frozen
-fruit fuel fun funny furnace fury future gadget gain galaxy gallery game gap garage garbage garden garlic garment gas gasp gate gather gauge gaze general
-genius genre gentle genuine gesture ghost giant gift giggle ginger giraffe girl give glad glance glare glass glide glimpse globe gloom glory glove glow glue
-goat goddess gold good goose gorilla gospel gossip govern gown grab grace grain grant grape grass gravity great green grid grief grit grocery group grow
-grunt guard guess guide guilt guitar gun gym habit hair half hammer hamster hand happy harbor hard harsh harvest hat have hawk hazard head health
-heart heavy hedgehog height hello helmet help hen hero hidden high hill hint hip hire history hobby hockey hold hole holiday hollow home honey hood
-hope horn horror horse hospital host hotel hour hover hub huge human humble humor hundred hungry hunt hurdle hurry hurt husband hybrid ice icon idea
-identify idle ignore ill illegal illness image imitate immense immune impact impose improve impulse inch include income increase index indicate indoor industry infant inflict inform
-inhale inherit initial inject injury inmate inner innocent input inquiry insane insect inside inspire install intact interest into invest invite involve iron island isolate issue
-item ivory jacket jaguar jar jazz jealous jeans jelly jewel job join joke journey joy judge juice jump jungle junior junk just kangaroo keen keep
-ketchup key kick kid kidney kind kingdom kiss kit kitchen kite kitten kiwi knee knife knock know lab label labor ladder lady lake lamp language
-laptop large later latin laugh laundry lava law lawn lawsuit layer lazy leader leaf learn leave lecture left leg legal legend leisure lemon lend length
-lens leopard lesson letter level liar liberty library license life lift light like limb limit link lion liquid list little live lizard load loan lobster
-local lock logic lonely long loop lottery loud lounge love loyal lucky luggage lumber lunar lunch luxury lyrics machine mad magic magnet maid mail main
-major make mammal man manage mandate mango mansion manual maple marble march margin marine market marriage mask mass master match material math matrix matter maximum
-maze meadow mean measure meat mechanic medal media melody melt member memory mention menu mercy merge merit merry mesh message metal method middle midnight milk
-million mimic mind minimum minor minute miracle mirror misery miss mistake mix mixed mixture mobile model modify mom moment monitor monkey monster month moon moral
-more morning mosquito mother motion motor mountain mouse move movie much muffin mule multiply muscle museum mushroom music must mutual myself mystery myth naive name
-napkin narrow nasty nation nature near neck need negative neglect neither nephew nerve nest net network neutral never news next nice night noble noise nominee
-noodle normal north nose notable note nothing notice novel now nuclear number nurse nut oak obey object oblige obscure observe obtain obvious occur ocean october
-odor off offer office often oil okay old olive olympic omit once one onion online only open opera opinion oppose option orange orbit orchard order
-ordinary organ orient original orphan ostrich other outdoor outer output outside oval oven over own owner oxygen oyster ozone pact paddle page pair palace palm
-panda panel panic panther paper parade parent park parrot party pass patch path patient patrol pattern pause pave payment peace peanut pear peasant pelican pen
-penalty pencil people pepper perfect permit person pet phone photo phrase physical piano picnic picture piece pig pigeon pill pilot pink pioneer pipe pistol pitch
-pizza place planet plastic plate play please pledge pluck plug plunge poem poet point polar pole police pond pony pool popular portion position possible post
-potato pottery poverty powder power practice praise predict prefer prepare present pretty prevent price pride primary print priority prison private prize problem process produce profit
-program project promote proof property prosper protect proud provide public pudding pull pulp pulse pumpkin punch pupil puppy purchase purity purpose purse push put puzzle
-pyramid quality quantum quarter question quick quit quiz quote rabbit raccoon race rack radar radio rail rain raise rally ramp ranch random range rapid rare
-rate rather raven raw razor ready real reason rebel rebuild recall receive recipe record recycle reduce reflect reform refuse region regret regular reject relax release
-relief rely remain remember remind remove render renew rent reopen repair repeat replace report require rescue resemble resist resource response result retire retreat return reunion
-reveal review reward rhythm rib ribbon rice rich ride ridge rifle right rigid ring riot ripple risk ritual rival river road roast robot robust rocket
-romance roof rookie room rose rotate rough round route royal rubber rude rug rule run runway rural sad saddle sadness safe sail salad salmon salon
-salt salute same sample sand satisfy satoshi sauce sausage save say scale scan scare scatter scene scheme school science scissors scorpion scout scrap screen script
-scrub sea search season seat second secret section security seed seek segment select sell seminar senior sense sentence series service session settle setup seven shadow
-shaft shallow share shed shell sheriff shield shift shine ship shiver shock shoe shoot shop short shoulder shove shrimp shrug shuffle shy sibling sick side
-siege sight sign silent silk silly silver similar simple since sing siren sister situate six size skate sketch ski skill skin skirt skull slab slam
-sleep slender slice slide slight slim slogan slot slow slush small smart smile smoke smooth snack snake snap sniff snow soap soccer social sock soda
-soft solar soldier solid solution solve someone song soon sorry sort soul sound soup source south space spare spatial spawn speak special speed spell spend
-sphere spice spider spike spin spirit split spoil sponsor spoon sport spot spray spread spring spy square squeeze squirrel stable stadium staff stage stairs stamp
-stand start state stay steak steel stem step stereo stick still sting stock stomach stone stool story stove strategy street strike strong struggle student stuff
-stumble style subject submit subway success such sudden suffer sugar suggest suit summer sun sunny sunset super supply supreme sure surface surge surprise surround survey
-suspect sustain swallow swamp swap swarm swear sweet swift swim swing switch sword symbol symptom syrup system table tackle tag tail talent talk tank tape
-target task taste tattoo taxi teach team tell ten tenant tennis tent term test text thank that theme then theory there they thing this thought
-three thrive throw thumb thunder ticket tide tiger tilt timber time tiny tip tired tissue title toast tobacco today toddler toe together toilet token tomato
-tomorrow tone tongue tonight tool tooth top topic topple torch tornado tortoise toss total tourist toward tower town toy track trade traffic tragic train transfer
-trap trash travel tray treat tree trend trial tribe trick trigger trim trip trophy trouble truck true truly trumpet trust truth try tube tuition tumble
-tuna tunnel turkey turn turtle twelve twenty twice twin twist two type typical ugly umbrella unable unaware uncle uncover under undo unfair unfold unhappy uniform
-unique unit universe unknown unlock until unusual unveil update upgrade uphold upon upper upset urban urge usage use used useful useless usual utility vacant vacuum
-vague valid valley valve van vanish vapor various vast vault vehicle velvet vendor venture venue verb verify version very vessel veteran viable vibrant vicious victory
-video view village vintage violin virtual virus visa visit visual vital vivid vocal voice void volcano volume vote voyage wage wagon wait walk wall walnut
-want warfare warm warrior wash wasp waste water wave way wealth weapon wear weasel weather web wedding weekend weird welcome west wet whale what wheat
-wheel when where whip whisper wide width wife wild will win window wine wing wink winner winter wire wisdom wise wish witness wolf woman wonder
-wood wool word work world worry worth wrap wreck wrestle wrist write wrong yard year yellow you young youth zebra zero zone zoo
+      WORDLIST_ENGLISH = <<-TEXT.freeze
+        abandon ability able about above absent absorb abstract absurd abuse access accident account accuse achieve acid acoustic acquire across act action actor actress actual adapt
+        add addict address adjust admit adult advance advice aerobic affair afford afraid again age agent agree ahead aim air airport aisle alarm album alcohol alert
+        alien all alley allow almost alone alpha already also alter always amateur amazing among amount amused analyst anchor ancient anger angle angry animal ankle announce
+        annual another answer antenna antique anxiety any apart apology appear apple approve april arch arctic area arena argue arm armed armor army around arrange arrest
+        arrive arrow art artefact artist artwork ask aspect assault asset assist assume asthma athlete atom attack attend attitude attract auction audit august aunt author auto
+        autumn average avocado avoid awake aware away awesome awful awkward axis baby bachelor bacon badge bag balance balcony ball bamboo banana banner bar barely bargain
+        barrel base basic basket battle beach bean beauty because become beef before begin behave behind believe below belt bench benefit best betray better between beyond
+        bicycle bid bike bind biology bird birth bitter black blade blame blanket blast bleak bless blind blood blossom blouse blue blur blush board boat body
+        boil bomb bone bonus book boost border boring borrow boss bottom bounce box boy bracket brain brand brass brave bread breeze brick bridge brief bright
+        bring brisk broccoli broken bronze broom brother brown brush bubble buddy budget buffalo build bulb bulk bullet bundle bunker burden burger burst bus business busy
+        butter buyer buzz cabbage cabin cable cactus cage cake call calm camera camp can canal cancel candy cannon canoe canvas canyon capable capital captain car
+        carbon card cargo carpet carry cart case cash casino castle casual cat catalog catch category cattle caught cause caution cave ceiling celery cement census century
+        cereal certain chair chalk champion change chaos chapter charge chase chat cheap check cheese chef cherry chest chicken chief child chimney choice choose chronic chuckle
+        chunk churn cigar cinnamon circle citizen city civil claim clap clarify claw clay clean clerk clever click client cliff climb clinic clip clock clog close
+        cloth cloud clown club clump cluster clutch coach coast coconut code coffee coil coin collect color column combine come comfort comic common company concert conduct
+        confirm congress connect consider control convince cook cool copper copy coral core corn correct cost cotton couch country couple course cousin cover coyote crack cradle
+        craft cram crane crash crater crawl crazy cream credit creek crew cricket crime crisp critic crop cross crouch crowd crucial cruel cruise crumble crunch crush
+        cry crystal cube culture cup cupboard curious current curtain curve cushion custom cute cycle dad damage damp dance danger daring dash daughter dawn day deal
+        debate debris decade december decide decline decorate decrease deer defense define defy degree delay deliver demand demise denial dentist deny depart depend deposit depth deputy
+        derive describe desert design desk despair destroy detail detect develop device devote diagram dial diamond diary dice diesel diet differ digital dignity dilemma dinner dinosaur
+        direct dirt disagree discover disease dish dismiss disorder display distance divert divide divorce dizzy doctor document dog doll dolphin domain donate donkey donor door dose
+        double dove draft dragon drama drastic draw dream dress drift drill drink drip drive drop drum dry duck dumb dune during dust dutch duty dwarf
+        dynamic eager eagle early earn earth easily east easy echo ecology economy edge edit educate effort egg eight either elbow elder electric elegant element elephant
+        elevator elite else embark embody embrace emerge emotion employ empower empty enable enact end endless endorse enemy energy enforce engage engine enhance enjoy enlist enough
+        enrich enroll ensure enter entire entry envelope episode equal equip era erase erode erosion error erupt escape essay essence estate eternal ethics evidence evil evoke
+        evolve exact example excess exchange excite exclude excuse execute exercise exhaust exhibit exile exist exit exotic expand expect expire explain expose express extend extra eye
+        eyebrow fabric face faculty fade faint faith fall false fame family famous fan fancy fantasy farm fashion fat fatal father fatigue fault favorite feature february
+        federal fee feed feel female fence festival fetch fever few fiber fiction field figure file film filter final find fine finger finish fire firm first
+        fiscal fish fit fitness fix flag flame flash flat flavor flee flight flip float flock floor flower fluid flush fly foam focus fog foil fold
+        follow food foot force forest forget fork fortune forum forward fossil foster found fox fragile frame frequent fresh friend fringe frog front frost frown frozen
+        fruit fuel fun funny furnace fury future gadget gain galaxy gallery game gap garage garbage garden garlic garment gas gasp gate gather gauge gaze general
+        genius genre gentle genuine gesture ghost giant gift giggle ginger giraffe girl give glad glance glare glass glide glimpse globe gloom glory glove glow glue
+        goat goddess gold good goose gorilla gospel gossip govern gown grab grace grain grant grape grass gravity great green grid grief grit grocery group grow
+        grunt guard guess guide guilt guitar gun gym habit hair half hammer hamster hand happy harbor hard harsh harvest hat have hawk hazard head health
+        heart heavy hedgehog height hello helmet help hen hero hidden high hill hint hip hire history hobby hockey hold hole holiday hollow home honey hood
+        hope horn horror horse hospital host hotel hour hover hub huge human humble humor hundred hungry hunt hurdle hurry hurt husband hybrid ice icon idea
+        identify idle ignore ill illegal illness image imitate immense immune impact impose improve impulse inch include income increase index indicate indoor industry infant inflict inform
+        inhale inherit initial inject injury inmate inner innocent input inquiry insane insect inside inspire install intact interest into invest invite involve iron island isolate issue
+        item ivory jacket jaguar jar jazz jealous jeans jelly jewel job join joke journey joy judge juice jump jungle junior junk just kangaroo keen keep
+        ketchup key kick kid kidney kind kingdom kiss kit kitchen kite kitten kiwi knee knife knock know lab label labor ladder lady lake lamp language
+        laptop large later latin laugh laundry lava law lawn lawsuit layer lazy leader leaf learn leave lecture left leg legal legend leisure lemon lend length
+        lens leopard lesson letter level liar liberty library license life lift light like limb limit link lion liquid list little live lizard load loan lobster
+        local lock logic lonely long loop lottery loud lounge love loyal lucky luggage lumber lunar lunch luxury lyrics machine mad magic magnet maid mail main
+        major make mammal man manage mandate mango mansion manual maple marble march margin marine market marriage mask mass master match material math matrix matter maximum
+        maze meadow mean measure meat mechanic medal media melody melt member memory mention menu mercy merge merit merry mesh message metal method middle midnight milk
+        million mimic mind minimum minor minute miracle mirror misery miss mistake mix mixed mixture mobile model modify mom moment monitor monkey monster month moon moral
+        more morning mosquito mother motion motor mountain mouse move movie much muffin mule multiply muscle museum mushroom music must mutual myself mystery myth naive name
+        napkin narrow nasty nation nature near neck need negative neglect neither nephew nerve nest net network neutral never news next nice night noble noise nominee
+        noodle normal north nose notable note nothing notice novel now nuclear number nurse nut oak obey object oblige obscure observe obtain obvious occur ocean october
+        odor off offer office often oil okay old olive olympic omit once one onion online only open opera opinion oppose option orange orbit orchard order
+        ordinary organ orient original orphan ostrich other outdoor outer output outside oval oven over own owner oxygen oyster ozone pact paddle page pair palace palm
+        panda panel panic panther paper parade parent park parrot party pass patch path patient patrol pattern pause pave payment peace peanut pear peasant pelican pen
+        penalty pencil people pepper perfect permit person pet phone photo phrase physical piano picnic picture piece pig pigeon pill pilot pink pioneer pipe pistol pitch
+        pizza place planet plastic plate play please pledge pluck plug plunge poem poet point polar pole police pond pony pool popular portion position possible post
+        potato pottery poverty powder power practice praise predict prefer prepare present pretty prevent price pride primary print priority prison private prize problem process produce profit
+        program project promote proof property prosper protect proud provide public pudding pull pulp pulse pumpkin punch pupil puppy purchase purity purpose purse push put puzzle
+        pyramid quality quantum quarter question quick quit quiz quote rabbit raccoon race rack radar radio rail rain raise rally ramp ranch random range rapid rare
+        rate rather raven raw razor ready real reason rebel rebuild recall receive recipe record recycle reduce reflect reform refuse region regret regular reject relax release
+        relief rely remain remember remind remove render renew rent reopen repair repeat replace report require rescue resemble resist resource response result retire retreat return reunion
+        reveal review reward rhythm rib ribbon rice rich ride ridge rifle right rigid ring riot ripple risk ritual rival river road roast robot robust rocket
+        romance roof rookie room rose rotate rough round route royal rubber rude rug rule run runway rural sad saddle sadness safe sail salad salmon salon
+        salt salute same sample sand satisfy satoshi sauce sausage save say scale scan scare scatter scene scheme school science scissors scorpion scout scrap screen script
+        scrub sea search season seat second secret section security seed seek segment select sell seminar senior sense sentence series service session settle setup seven shadow
+        shaft shallow share shed shell sheriff shield shift shine ship shiver shock shoe shoot shop short shoulder shove shrimp shrug shuffle shy sibling sick side
+        siege sight sign silent silk silly silver similar simple since sing siren sister situate six size skate sketch ski skill skin skirt skull slab slam
+        sleep slender slice slide slight slim slogan slot slow slush small smart smile smoke smooth snack snake snap sniff snow soap soccer social sock soda
+        soft solar soldier solid solution solve someone song soon sorry sort soul sound soup source south space spare spatial spawn speak special speed spell spend
+        sphere spice spider spike spin spirit split spoil sponsor spoon sport spot spray spread spring spy square squeeze squirrel stable stadium staff stage stairs stamp
+        stand start state stay steak steel stem step stereo stick still sting stock stomach stone stool story stove strategy street strike strong struggle student stuff
+        stumble style subject submit subway success such sudden suffer sugar suggest suit summer sun sunny sunset super supply supreme sure surface surge surprise surround survey
+        suspect sustain swallow swamp swap swarm swear sweet swift swim swing switch sword symbol symptom syrup system table tackle tag tail talent talk tank tape
+        target task taste tattoo taxi teach team tell ten tenant tennis tent term test text thank that theme then theory there they thing this thought
+        three thrive throw thumb thunder ticket tide tiger tilt timber time tiny tip tired tissue title toast tobacco today toddler toe together toilet token tomato
+        tomorrow tone tongue tonight tool tooth top topic topple torch tornado tortoise toss total tourist toward tower town toy track trade traffic tragic train transfer
+        trap trash travel tray treat tree trend trial tribe trick trigger trim trip trophy trouble truck true truly trumpet trust truth try tube tuition tumble
+        tuna tunnel turkey turn turtle twelve twenty twice twin twist two type typical ugly umbrella unable unaware uncle uncover under undo unfair unfold unhappy uniform
+        unique unit universe unknown unlock until unusual unveil update upgrade uphold upon upper upset urban urge usage use used useful useless usual utility vacant vacuum
+        vague valid valley valve van vanish vapor various vast vault vehicle velvet vendor venture venue verb verify version very vessel veteran viable vibrant vicious victory
+        video view village vintage violin virtual virus visa visit visual vital vivid vocal voice void volcano volume vote voyage wage wagon wait walk wall walnut
+        want warfare warm warrior wash wasp waste water wave way wealth weapon wear weasel weather web wedding weekend weird welcome west wet whale what wheat
+        wheel when where whip whisper wide width wife wild will win window wine wing wink winner winter wire wisdom wise wish witness wolf woman wonder
+        wood wool word work world worry worth wrap wreck wrestle wrist write wrong yard year yellow you young youth zebra zero zone zoo
       TEXT
     end
-
   end
 end


### PR DESCRIPTION
This is an incremental patch to get the bitcoin-ruby codebase conformed to a uniform code quality standard using rubocop.

Fixed files:
- `lib/bitcoin/electrum/mnemonic.rb`
- `lib/bitcoin/ffi/bitcoinconsensus.rb`
- `lib/bitcoin/ffi/openssl.rb`
- `lib/bitcoin/ffi/secp256k1.rb`
- `lib/bitcoin/trezor/mnemonic.rb`

Updated Rubocop configs:
- `Metrics/BlockLength` maximum of 50
- `Metrics/ModuleLength` maximum of 500