### PR TITLE
Rubocop fixes for some utils

### DIFF
--- a/lib/bitcoin/bech32.rb
+++ b/lib/bitcoin/bech32.rb
@@ -1,172 +1,166 @@
 # encoding: ascii-8bit
-# Ruby reference implementation: https://github.com/sipa/bech32/tree/master/ref/c
-module Bitcoin; end
-module Bitcoin::Bech32
 
-  CHARSET = "qpzry9x8gf2tvdw0s3jn54khce6mua7l".unpack("C*")
-  CHARSET_REV = [
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
-    15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
-    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
-     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
-    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
-     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
-  ]
+module Bitcoin
+  # Ruby reference implementation: https://github.com/sipa/bech32/tree/master/ref/c
+  module Bech32
+    CHARSET = 'qpzry9x8gf2tvdw0s3jn54khce6mua7l'.unpack('C*')
+    CHARSET_REV = [
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+      15, -1, 10, 17, 21, 20, 26, 30, 7, 5, -1, -1, -1, -1, -1, -1,
+      -1, 29, -1, 24, 13, 25, 9, 8, 23, -1, 18, 22, 31, 27, 19, -1,
+      1,  0,  3, 16, 11, 28, 12, 14, 6, 4, 2, -1, -1, -1, -1, -1,
+      -1, 29, -1, 24, 13, 25, 9, 8, 23, -1, 18, 22, 31, 27, 19, -1,
+      1,  0,  3, 16, 11, 28, 12, 14, 6, 4, 2, -1, -1, -1, -1, -1
+    ].freeze
 
-  class << self
-
-    def polymod_step(pre)
-      b = pre >> 25
-      return ((pre & 0x1FFFFFF) << 5) ^ \
+    class << self
+      def polymod_step(pre)
+        b = pre >> 25
+        ((pre & 0x1FFFFFF) << 5) ^ \
           (-((b >> 0) & 1) & 0x3b6a57b2) ^ \
           (-((b >> 1) & 1) & 0x26508e6d) ^ \
           (-((b >> 2) & 1) & 0x1ea119fa) ^ \
           (-((b >> 3) & 1) & 0x3d4233dd) ^ \
           (-((b >> 4) & 1) & 0x2a1462b3)
-    end
-
-    def encode(hrp, data)
-      buf = []
-      chk = 1
-
-      hrp.unpack("C*").each do |ch|
-        return nil if ch < 33 || ch > 126
-        return nil if ch >= 'A'.ord && ch <= 'Z'.ord
-        chk = polymod_step(chk) ^ (ch >> 5)
       end
 
-      return nil if (hrp.bytesize + 7 + data.size) > 90
+      def encode(hrp, data)
+        buf = []
+        chk = 1
 
-      chk = polymod_step(chk)
-      hrp.unpack("C*").each do |ch|
-        chk = polymod_step(chk) ^ (ch & 0x1f)
-        buf << ch
-      end
+        hrp.unpack('C*').each do |ch|
+          return nil if ch < 33 || ch > 126
+          return nil if ch >= 'A'.ord && ch <= 'Z'.ord
+          chk = polymod_step(chk) ^ (ch >> 5)
+        end
 
-      buf << '1'.ord
+        return nil if (hrp.bytesize + 7 + data.size) > 90
 
-      data.each do |i|
-        return nil if (i >> 5) != 0
-        chk = polymod_step(chk) ^ i
-        buf << CHARSET[i]
-      end
-
-      6.times do |n|
         chk = polymod_step(chk)
-      end
-
-      chk ^= 1
-
-      6.times do |i|
-        buf << CHARSET[(chk >> ((5 - i) * 5)) & 0x1f]
-      end
-
-      return buf.pack("C*")
-    end
-
-    def decode(input)
-      chk = 1
-      input_len = input.bytesize
-      have_lower, have_upper = false, false
-
-      return nil if input_len < 8 || input_len > 90
-
-      data_len = 0
-      while data_len < input_len && input[(input_len - 1) - data_len] != '1' do
-        data_len += 1
-      end
-
-      hrp_len = input_len - (1 + data_len)
-      return nil if hrp_len < 1 || data_len < 6
-
-      data_len -= 6
-
-      hrp = []
-      hrp_len.times do |i|
-        ch = input[i].ord
-        return nil if ch < 33 || ch > 126
-
-        if ch >= 'a'.ord && ch <= 'z'.ord
-          have_lower = true
-        elsif ch >= 'A'.ord && ch <= 'Z'.ord
-          have_upper = true
-          ch = (ch - 'A'.ord) + 'a'.ord
+        hrp.unpack('C*').each do |ch|
+          chk = polymod_step(chk) ^ (ch & 0x1f)
+          buf << ch
         end
 
-        hrp << ch
-        chk = polymod_step(chk) ^ (ch >> 5)
-      end
+        buf << '1'.ord
 
-      chk = polymod_step(chk)
-
-      hrp_len.times do |i|
-        chk = polymod_step(chk) ^ (input[i].ord & 0x1f)
-      end
-
-      data = []
-      i = hrp_len + 1
-      while i < input_len do
-        ch = input[i].ord
-        v = ((ch & 0x80) != 0) ? -1 : CHARSET_REV[ch]
-
-        have_lower = true if ch >= 'a'.ord && ch <= 'z'.ord
-        have_upper = true if ch >= 'A'.ord && ch <= 'Z'.ord
-        return nil if v == -1
-
-        chk = polymod_step(chk) ^ v
-        if (i + 6) < input_len
-          data << v
+        data.each do |i|
+          return nil if (i >> 5) != 0
+          chk = polymod_step(chk) ^ i
+          buf << CHARSET[i]
         end
-        i += 1
-      end
 
-      return nil if have_lower && have_upper
-      return nil if chk != 1
-
-      return [hrp.pack("C*"), data]
-    end
-
-    # Utility for converting bytes of data between bases. These is used for
-    # BIP 173 address encoding/decoding to convert between sequences of bytes
-    # representing 8-bit values and groups of 5 bits. Conversions may be padded
-    # with trailing 0 bits to the nearest byte boundary. Returns nil if
-    # conversion requires padding and pad is false.
-    #
-    # For example:
-    #
-    #   convert_bits("\xFF\xFF", from_bits: 8, to_bits: 5, pad: true)
-    #     => "\x1F\x1F\x1F\10"
-    #
-    # See https://github.com/bitcoin/bitcoin/blob/595a7bab23bc21049526229054ea1fff1a29c0bf/src/utilstrencodings.h#L154
-    def convert_bits(chunks, from_bits:, to_bits:, pad:)
-      output_mask = (1 << to_bits) - 1
-      buffer_mask = (1 << (from_bits + to_bits - 1)) - 1
-
-      buffer = 0
-      bits = 0
-
-      output = []
-      chunks.each do |chunk|
-        buffer = ((buffer << from_bits) | chunk) & buffer_mask
-        bits += from_bits
-        while bits >= to_bits
-          bits -= to_bits
-          output << ((buffer >> bits) & output_mask)
+        6.times do
+          chk = polymod_step(chk)
         end
+
+        chk ^= 1
+
+        6.times do |i|
+          buf << CHARSET[(chk >> ((5 - i) * 5)) & 0x1f]
+        end
+
+        buf.pack('C*')
       end
 
-      if pad && bits > 0
-        output << ((buffer << (to_bits - bits)) & output_mask)
-      end
+      # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+      def decode(input)
+        chk = 1
+        input_len = input.bytesize
+        have_lower = false
+        have_upper = false
 
-      if !pad && (bits >= from_bits || ((buffer << (to_bits - bits)) & output_mask) != 0)
-        return nil
-      end
+        return nil if input_len < 8 || input_len > 90
 
-      output
+        data_len = 0
+        data_len += 1 while data_len < input_len && input[(input_len - 1) - data_len] != '1'
+
+        hrp_len = input_len - (1 + data_len)
+        return nil if hrp_len < 1 || data_len < 6
+
+        hrp = []
+        hrp_len.times do |i|
+          ch = input[i].ord
+          return nil if ch < 33 || ch > 126
+
+          if ch >= 'a'.ord && ch <= 'z'.ord
+            have_lower = true
+          elsif ch >= 'A'.ord && ch <= 'Z'.ord
+            have_upper = true
+            ch = (ch - 'A'.ord) + 'a'.ord
+          end
+
+          hrp << ch
+          chk = polymod_step(chk) ^ (ch >> 5)
+        end
+
+        chk = polymod_step(chk)
+
+        hrp_len.times do |i|
+          chk = polymod_step(chk) ^ (input[i].ord & 0x1f)
+        end
+
+        data = []
+        i = hrp_len + 1
+        while i < input_len
+          ch = input[i].ord
+          v = (ch & 0x80) != 0 ? -1 : CHARSET_REV[ch]
+
+          have_lower = true if ch >= 'a'.ord && ch <= 'z'.ord
+          have_upper = true if ch >= 'A'.ord && ch <= 'Z'.ord
+          return nil if v == -1
+
+          chk = polymod_step(chk) ^ v
+          data << v if (i + 6) < input_len
+          i += 1
+        end
+
+        return nil if have_lower && have_upper
+        return nil if chk != 1
+
+        [hrp.pack('C*'), data]
+      end
+      # rubocop:enable CyclomaticComplexity,PerceivedComplexity
+
+      # Utility for converting bytes of data between bases. These is used for
+      # BIP 173 address encoding/decoding to convert between sequences of bytes
+      # representing 8-bit values and groups of 5 bits. Conversions may be padded
+      # with trailing 0 bits to the nearest byte boundary. Returns nil if
+      # conversion requires padding and pad is false.
+      #
+      # For example:
+      #
+      #   convert_bits("\xFF\xFF", from_bits: 8, to_bits: 5, pad: true)
+      #     => "\x1F\x1F\x1F\10"
+      #
+      # See https://github.com/bitcoin/bitcoin/blob/595a7bab23bc21049526229054ea1fff1a29c0bf/src/utilstrencodings.h#L154
+      def convert_bits(chunks, from_bits:, to_bits:, pad:)
+        output_mask = (1 << to_bits) - 1
+        buffer_mask = (1 << (from_bits + to_bits - 1)) - 1
+
+        buffer = 0
+        bits = 0
+
+        output = []
+        chunks.each do |chunk|
+          buffer = ((buffer << from_bits) | chunk) & buffer_mask
+          bits += from_bits
+          while bits >= to_bits
+            bits -= to_bits
+            output << ((buffer >> bits) & output_mask)
+          end
+        end
+
+        output << ((buffer << (to_bits - bits)) & output_mask) if pad && bits > 0
+
+        if !pad && (bits >= from_bits || ((buffer << (to_bits - bits)) & output_mask) != 0)
+          return nil
+        end
+
+        output
+      end
     end
-
   end
 end

--- a/lib/bitcoin/bloom_filter.rb
+++ b/lib/bitcoin/bloom_filter.rb
@@ -1,9 +1,10 @@
 module Bitcoin
+  # https://github.com/bitcoin/bips/blob/master/bip-0037.mediawiki
   class BloomFilter
     SEED_SHIFT = 0xfba4c795
-    BIT_MASK = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80]
+    BIT_MASK = [0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80].freeze
 
-    MAX_FILTER_SIZE = 36000
+    MAX_FILTER_SIZE = 36_000
     MAX_HASH_FUNCS = 50
 
     # flags for filterload message
@@ -53,8 +54,8 @@ module Bitcoin
 
       # using #ceil instead of #floor may be better, but it's bitcoinj's way
 
-      calc_m = (-Math.log(fp_rate) * elements / ln2 / ln2 / 8).floor;
-      @filter_size = [1, [calc_m, MAX_FILTER_SIZE].min].max;
+      calc_m = (-Math.log(fp_rate) * elements / ln2 / ln2 / 8).floor
+      @filter_size = [1, [calc_m, MAX_FILTER_SIZE].min].max
       @filter = "\x00" * @filter_size
 
       calc_k = (@filter_size * 8 * ln2 / elements).floor
@@ -62,7 +63,7 @@ module Bitcoin
     end
 
     def rotate_left32(x, r)
-      return (x << r) | (x >> (32 - r))
+      (x << r) | (x >> (32 - r))
     end
 
     #
@@ -80,13 +81,15 @@ module Bitcoin
       # body
       while i < num_blocks
         k1 = (object[i] & 0xFF) |
-            ((object[i + 1] & 0xFF) << 8) |
-            ((object[i + 2] & 0xFF) << 16) |
-            ((object[i + 3] & 0xFF) << 24)
+             ((object[i + 1] & 0xFF) << 8) |
+             ((object[i + 2] & 0xFF) << 16) |
+             ((object[i + 3] & 0xFF) << 24)
 
-        k1 *= c1; k1 &= 0xffffffff
+        k1 *= c1
+        k1 &= 0xffffffff
         k1 = rotate_left32(k1, 15)
-        k1 *= c2; k1 &= 0xffffffff
+        k1 *= c2
+        k1 &= 0xffffffff
 
         h1 ^= k1
         h1 = rotate_left32(h1, 13)
@@ -97,29 +100,29 @@ module Bitcoin
 
       k1 = 0
       flg = object.length & 3
-      if flg >= 3
-        k1 ^= (object[num_blocks + 2] & 0xff) << 16
-      end
-      if flg >= 2
-        k1 ^= (object[num_blocks + 1] & 0xff) << 8
-      end
+      k1 ^= (object[num_blocks + 2] & 0xff) << 16 if flg >= 3
+      k1 ^= (object[num_blocks + 1] & 0xff) << 8 if flg >= 2
       if flg >= 1
         k1 ^= (object[num_blocks] & 0xff)
-        k1 *= c1; k1 &= 0xffffffff
+        k1 *= c1
+        k1 &= 0xffffffff
         k1 = rotate_left32(k1, 15)
-        k1 *= c2; k1 &= 0xffffffff
+        k1 *= c2
+        k1 &= 0xffffffff
         h1 ^= k1
       end
 
       # finalization
       h1 ^= object.length
       h1 ^= h1 >> 16
-      h1 *= 0x85ebca6b; h1 &= 0xffffffff
+      h1 *= 0x85ebca6b
+      h1 &= 0xffffffff
       h1 ^= h1 >> 13
-      h1 *= 0xc2b2ae35; h1 &= 0xffffffff
+      h1 *= 0xc2b2ae35
+      h1 &= 0xffffffff
       h1 ^= h1 >> 16
 
-      return (h1 & 0xffffffff) % (@filter_size * 8)
+      (h1 & 0xffffffff) % (@filter_size * 8)
     end
   end
 end

--- a/lib/bitcoin/builder.rb
+++ b/lib/bitcoin/builder.rb
@@ -1,15 +1,13 @@
 # encoding: ascii-8bit
 
 module Bitcoin
-
   # Optional DSL to help create blocks and transactions.
   #
   # see also BlockBuilder, TxBuilder, TxInBuilder, TxOutBuilder, ScriptBuilder
   module Builder
-
     # build a Bitcoin::Protocol::Block matching the given +target+.
     # see BlockBuilder for details.
-    def build_block(target = "00".ljust(64, 'f'))
+    def build_block(target = '00'.ljust(64, 'f'))
       c = BlockBuilder.new
       yield c
       c.block(target)
@@ -17,7 +15,7 @@ module Bitcoin
 
     # build a Bitcoin::Protocol::Tx.
     # see TxBuilder for details.
-    def build_tx opts = {}
+    def build_tx(opts = {})
       c = TxBuilder.new
       yield c
       c.tx opts
@@ -45,35 +43,46 @@ module Bitcoin
     #
     # See Bitcoin::Builder::TxBuilder for details on building transactions.
     class BlockBuilder
+      attr_writer :prev_block_hash, :time, :version
 
       def initialize
         @block = P::Block.new(nil)
       end
 
       # specify block version. this is usually not necessary. defaults to 1.
-      def version v
+      def version(v)
+        warn '[DEPRECATION] `BlockBuilder.version` is deprecated. ' \
+             'Use .version= instead.'
         @version = v
       end
 
       # set the hash of the previous block.
-      def prev_block hash
+      def prev_block(hash)
+        warn '[DEPRECATION] `BlockBuilder.prev_block` is deprecated. ' \
+             'Use .prev_block= instead.'
         @prev_block = hash
       end
 
       # set the block timestamp (defaults to current time).
-      def time time
+      def time(time)
+        warn '[DEPRECATION] `BlockBuilder.time` is deprecated. ' \
+             'Use .time= instead.'
         @time = time
       end
 
       # add transactions to the block (see TxBuilder).
-      def tx tx = nil
-        tx ||= ( c = TxBuilder.new; yield c; c.tx )
+      def tx(tx = nil)
+        tx ||= begin
+          c = TxBuilder.new
+          yield c
+          c.tx
+        end
         @block.tx << tx
         tx
       end
 
       # create the block according to values specified via DSL.
-      def block target
+      def block(target)
         @version ||= nil
         @mrkl_root ||= nil
         @time ||= nil
@@ -86,33 +95,31 @@ module Bitcoin
         @block.mrkl_root = Bitcoin.hash_mrkl_tree(@block.tx.map(&:hash)).last.htb.reverse
         find_hash(target)
         block = P::Block.new(@block.to_payload)
-        raise "Payload Error"  unless block.to_payload == @block.to_payload
+        raise 'Payload Error' unless block.to_payload == @block.to_payload
         block
       end
 
       private
 
       # increment nonce/time to find a block hash matching the +target+.
-      def find_hash target
+      def find_hash(target)
         @block.bits = Bitcoin.encode_compact_bits(target)
         t = Time.now
         @block.recalc_block_hash
         until @block.hash.to_i(16) < target.to_i(16)
           @block.nonce += 1
           @block.recalc_block_hash
-          if @block.nonce == 100000
-            if t
-              tt = 1 / ((Time.now - t) / 100000) / 1000
-              print "\r%.2f khash/s" % tt
-            end
-            t = Time.now
-            @block.time = Time.now.to_i
-            @block.nonce = 0
-            $stdout.flush
+          next unless @block.nonce == 100_000
+          if t
+            tt = 1 / ((Time.now - t) / 100_000) / 1000
+            print format("\r%.2f khash/s", tt)
           end
+          t = Time.now
+          @block.time = Time.now.to_i
+          @block.nonce = 0
+          $stdout.flush
         end
       end
-
     end
 
     # DSL to create Bitcoin::Protocol::Tx used by Builder#build_tx.
@@ -133,20 +140,21 @@ module Bitcoin
     #
     # See TxInBuilder and TxOutBuilder for details on how to build in/outputs.
     class TxBuilder
-
       def initialize
         @tx = P::Tx.new(nil)
-        @tx.ver, @tx.lock_time = 1, 0
-        @ins, @outs = [], []
+        @tx.ver = 1
+        @tx.lock_time = 0
+        @ins = []
+        @outs = []
       end
 
       # specify tx version. this is usually not necessary. defaults to 1.
-      def version n
+      def version(n)
         @tx.ver = n
       end
 
       # specify tx lock_time. this is usually not necessary. defaults to 0.
-      def lock_time n
+      def lock_time(n)
         @tx.lock_time = n
       end
 
@@ -158,10 +166,10 @@ module Bitcoin
       end
 
       # add an output to the transaction (see TxOutBuilder).
-      def output value = nil, recipient = nil, type = :address
+      def output(value = nil, recipient = nil, type = :address)
         c = TxOutBuilder.new
         c.value(value)  if value
-        c.to(recipient, type)  if recipient
+        c.to(recipient, type) if recipient
         yield c  if block_given?
         @outs << c
       end
@@ -176,14 +184,15 @@ module Bitcoin
       # to the given address. The :leave_fee option can be used in this
       # case to specify a tx fee that should be left unclaimed by the
       # change output.
-      def tx opts = {}
+      # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+      def tx(opts = {})
         return @tx  if @tx.hash
 
         if opts[:change_address] && !opts[:input_value]
           raise "Must give 'input_value' when auto-generating change output!"
         end
-        @ins.each {|i| @tx.add_in(i.txin) }
-        @outs.each {|o| @tx.add_out(o.txout) }
+        @ins.each { |i| @tx.add_in(i.txin) }
+        @outs.each { |o| @tx.add_out(o.txout) }
         if opts[:change_address]
           output_value = @tx.out.map(&:value).inject(:+) || 0
           change_value = opts[:input_value] - output_value
@@ -206,7 +215,7 @@ module Bitcoin
         end
 
         # run our tx through an encode/decode cycle to make sure that the binary format is sane
-        raise "Payload Error"  unless P::Tx.new(@tx.to_witness_payload).to_payload == @tx.to_payload
+        raise 'Payload Error' unless P::Tx.new(@tx.to_witness_payload).to_payload == @tx.to_payload
         @tx.instance_eval do
           @payload = to_payload
           @hash = hash_from_payload(@payload)
@@ -214,38 +223,44 @@ module Bitcoin
 
         @tx
       end
+      # rubocop:enable CyclomaticComplexity,PerceivedComplexity
 
       # coinbase inputs don't need to be signed, they only include the given +coinbase_data+
-      def include_coinbase_data i, inc
-        script_sig = [inc.coinbase_data].pack("H*")
+      def include_coinbase_data(i, inc)
+        script_sig = [inc.coinbase_data].pack('H*')
         @tx.in[i].script_sig_length = script_sig.bytesize
         @tx.in[i].script_sig = script_sig
       end
 
       def sig_hash_and_all_keys_exist?(inc, sig_script)
-        return false unless @sig_hash && inc.has_keys?
+        return false unless @sig_hash && inc.keys?
         script = Bitcoin::Script.new(sig_script)
-        return true if script.is_hash160? || script.is_pubkey? || script.is_witness_v0_keyhash? || (Bitcoin.namecoin? && script.is_namecoin?)
+        return true if script.is_hash160? ||
+                       script.is_pubkey? ||
+                       script.is_witness_v0_keyhash? ||
+                       (Bitcoin.namecoin? && script.is_namecoin?)
         if script.is_multisig?
-          return inc.has_multiple_keys? && inc.key.size >= script.get_signatures_required
+          return inc.multiple_keys? && inc.key.size >= script.get_signatures_required
         end
-        raise "Script type must be hash160, pubkey, p2wpkh or multisig"
+        raise 'Script type must be hash160, pubkey, p2wpkh or multisig'
       end
 
       def add_empty_script_sig_to_input(i)
         @tx.in[i].script_sig_length = 0
-        @tx.in[i].script_sig = ""
+        @tx.in[i].script_sig = ''
         # add the sig_hash that needs to be signed, so it can be passed on to a signing device
         @tx.in[i].sig_hash = @sig_hash
-        # add the address the sig_hash needs to be signed with as a convenience for the signing device
-        @tx.in[i].sig_address = Script.new(@prev_script).get_address  if @prev_script
+        # add the address the sig_hash needs to be signed with as a convenience for the
+        # signing device
+        @tx.in[i].sig_address = Script.new(@prev_script).get_address if @prev_script
       end
 
       def get_script_sig(inc, hash_type)
-        if inc.has_multiple_keys?
+        if inc.multiple_keys?
           # multiple keys given, generate signature for each one
           sigs = inc.sign(@sig_hash)
-          if redeem_script = inc.instance_eval { @redeem_script }
+          redeem_script = inc.instance_eval { @redeem_script }
+          if redeem_script
             # when a redeem_script was specified, assume we spend a p2sh multisig script
             script_sig = Script.to_p2sh_multisig_script_sig(redeem_script, sigs)
           else
@@ -255,81 +270,80 @@ module Bitcoin
         else
           # only one key given, generate signature and script_sig
           sig = inc.sign(@sig_hash)
-          script_sig = Script.to_signature_pubkey_script(sig, [inc.key.pub].pack("H*"), hash_type)
+          script_sig = Script.to_signature_pubkey_script(sig, [inc.key.pub].pack('H*'), hash_type)
         end
-        return script_sig
+        script_sig
       end
 
       # Sign input number +i+ with data from given +inc+ object (a TxInBuilder).
-      def sign_input i, inc
-        if @tx.in[i].coinbase?
-          include_coinbase_data(i, inc)
+      # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+      def sign_input(i, inc)
+        return include_coinbase_data(i, inc) if @tx.in[i].coinbase?
+        @prev_script = inc.instance_variable_get(:@prev_out_script)
+
+        # get the signature script; use +redeem_script+ if given
+        # (indicates spending a p2sh output), otherwise use the prev_script
+        sig_script = inc.instance_eval { @redeem_script }
+        sig_script ||= @prev_script
+
+        hash_type = if inc.prev_out_forkid
+                      Script::SIGHASH_TYPE[:all] | Script::SIGHASH_TYPE[:forkid]
+                    else
+                      Script::SIGHASH_TYPE[:all]
+                    end
+
+        # when a sig_script was found, generate the sig_hash to be signed
+        if sig_script
+          script = Script.new(sig_script)
+          @sig_hash = if script.is_witness_v0_keyhash?
+                        @tx.signature_hash_for_witness_input(i, sig_script, inc.value)
+                      elsif inc.prev_out_forkid
+                        @tx.signature_hash_for_input(
+                          i,
+                          sig_script,
+                          hash_type,
+                          inc.value,
+                          inc.prev_out_forkid
+                        )
+                      else
+                        @tx.signature_hash_for_input(i, sig_script)
+                      end
+        end
+
+        # when there is a sig_hash and one or more signature_keys were specified
+        if sig_hash_and_all_keys_exist?(inc, sig_script)
+          # add the script_sig to the txin
+          if script.is_witness_v0_keyhash? # for p2wpkh
+            @tx.in[i].script_witness.stack << inc.sign(@sig_hash) + \
+                                              [Script::SIGHASH_TYPE[:all]].pack('C')
+            @tx.in[i].script_witness.stack << inc.key.pub.htb
+
+            redeem_script = inc.instance_eval { @redeem_script }
+            @tx.in[i].script_sig = Bitcoin::Script.pack_pushdata(redeem_script) if redeem_script
+          else
+            @tx.in[i].script_sig = get_script_sig(inc, hash_type)
+          end
+          # double-check that the script_sig is valid to spend the given prev_script
+          if @prev_script && !inc.prev_out_forkid
+            verified = if script.is_witness_v0_keyhash?
+                         @tx.verify_witness_input_signature(i, @prev_script, inc.value)
+                       else
+                         @tx.verify_input_signature(i, @prev_script)
+                       end
+            raise 'Signature error' unless verified
+          end
+        elsif inc.multiple_keys?
+          raise 'Keys missing for multisig signing'
         else
-          @prev_script = inc.instance_variable_get(:@prev_out_script)
-
-          # get the signature script; use +redeem_script+ if given
-          # (indicates spending a p2sh output), otherwise use the prev_script
-          sig_script = inc.instance_eval { @redeem_script }
-          sig_script ||= @prev_script
-
-          hash_type = if inc.prev_out_forkid
-            Script::SIGHASH_TYPE[:all] | Script::SIGHASH_TYPE[:forkid]
-          else
-            Script::SIGHASH_TYPE[:all]
-          end
-
-          # when a sig_script was found, generate the sig_hash to be signed
-          if sig_script
-            script = Script.new(sig_script)
-            if script.is_witness_v0_keyhash?
-              @sig_hash = @tx.signature_hash_for_witness_input(i, sig_script, inc.value)
-            else
-              @sig_hash = if inc.prev_out_forkid
-                @tx.signature_hash_for_input(
-                  i,
-                  sig_script,
-                  hash_type,
-                  inc.value,
-                  inc.prev_out_forkid)
-              else
-                @tx.signature_hash_for_input(i, sig_script)
-              end
-            end
-          end
-
-          # when there is a sig_hash and one or more signature_keys were specified
-          if sig_hash_and_all_keys_exist?(inc, sig_script)
-            # add the script_sig to the txin
-            if script.is_witness_v0_keyhash? # for p2wpkh
-              @tx.in[i].script_witness.stack << inc.sign(@sig_hash) + [Script::SIGHASH_TYPE[:all]].pack("C")
-              @tx.in[i].script_witness.stack << inc.key.pub.htb
-
-              redeem_script = inc.instance_eval { @redeem_script }
-              @tx.in[i].script_sig = Bitcoin::Script.pack_pushdata(redeem_script) if redeem_script
-            else
-              @tx.in[i].script_sig = get_script_sig(inc, hash_type)
-            end
-            # double-check that the script_sig is valid to spend the given prev_script
-            if @prev_script && !inc.prev_out_forkid
-              verified = if script.is_witness_v0_keyhash?
-                @tx.verify_witness_input_signature(i, @prev_script, inc.value)
-              else
-                @tx.verify_input_signature(i, @prev_script)
-              end
-              raise "Signature error" unless verified
-            end
-          elsif inc.has_multiple_keys?
-            raise "Keys missing for multisig signing"
-          else
-            # no sig_hash, add an empty script_sig.
-            add_empty_script_sig_to_input(i)
-          end
+          # no sig_hash, add an empty script_sig.
+          add_empty_script_sig_to_input(i)
         end
       end
+      # rubocop:enable CyclomaticComplexity,PerceivedComplexity
 
       # Randomize the outputs using SecureRandom
       def randomize_outputs
-        @outs.sort_by!{ SecureRandom.random_bytes(4).unpack("I")[0] }
+        @outs.sort_by! { SecureRandom.random_bytes(4).unpack('I')[0] }
       end
     end
 
@@ -358,7 +372,8 @@ module Bitcoin
     #
     # If you want to spend a multisig output, just provide an array of keys to #signature_key.
     class TxInBuilder
-      attr_reader :prev_tx, :prev_script, :key, :coinbase_data, :prev_out_forkid
+      attr_reader :coinbase_data, :key, :prev_out_forkid, :prev_script, :prev_tx
+      attr_writer :prev_out_script, :prev_out_value, :redeem_script, :sequence
 
       def initialize
         @txin = P::TxIn.new
@@ -372,33 +387,37 @@ module Bitcoin
       # You can either pass the transaction, or just the tx hash.
       # If you pass only the hash, you need to pass the previous outputs
       # +script+ separately if you want the txin to be signed.
-      def prev_out tx, idx = nil, script = nil, prev_value = nil, prev_forkid = nil
+      def prev_out(tx, idx = nil, script = nil, prev_value = nil, prev_forkid = nil)
         @prev_out_forkid = prev_forkid
         if tx.is_a?(Bitcoin::P::Tx)
           @prev_tx = tx
           @prev_out_hash = tx.binary_hash
-          @prev_out_script = tx.out[idx].pk_script  if idx
+          @prev_out_script = tx.out[idx].pk_script if idx
         else
           @prev_out_hash = tx.htb.reverse
         end
-        @prev_out_script = script  if script
-        @prev_out_index = idx  if idx
+        @prev_out_script = script if script
+        @prev_out_index = idx if idx
         @prev_out_value = prev_value if prev_value
       end
 
       # Index of the output in the #prev_out transaction.
-      def prev_out_index i
+      def prev_out_index(i)
         @prev_out_index = i
-        @prev_out_script = @prev_tx.out[i].pk_script  if @prev_tx
+        @prev_out_script = @prev_tx.out[i].pk_script if @prev_tx
       end
 
       # Previous output's +pk_script+. Needed when only the tx hash is specified as #prev_out.
-      def prev_out_script script
+      def prev_out_script(script)
+        warn '[DEPRECATION] `TxInBuilder.prev_out_script` is deprecated. ' \
+             'Use .prev_out_script= instead.'
         @prev_out_script = script
       end
 
       # Previous output's +value+. Needed when only spend segwit utxo.
       def prev_out_value(value)
+        warn '[DEPRECATION] `TxInBuilder.prev_out_value` is deprecated. ' \
+             'Use .prev_out_value= instead.'
         @prev_out_value = value
       end
 
@@ -409,26 +428,29 @@ module Bitcoin
       # Redeem script for P2SH output. To spend from a P2SH output, you need to provide
       # the script with a hash matching the P2SH address.
       def redeem_script(script)
+        warn '[DEPRECATION] `TxInBuilder.redeem_script` is deprecated. ' \
+             'Use .redeem_script= instead.'
         @redeem_script = script
       end
 
       # Specify sequence. This is usually not needed.
-      def sequence s
+      def sequence(s)
+        warn '[DEPRECATION] `TxInBuilder.sequence` is deprecated. Use .sequence= instead.'
         @sequence = s
       end
 
       # Bitcoin::Key used to sign the signature_hash for the input.
       # see Bitcoin::Script.signature_hash_for_input and Bitcoin::Key.sign.
-      def signature_key key
+      def signature_key(key)
         @key = key
       end
 
       # Specify that this is a coinbase input. Optionally set +data+.
       # If this is set, no other options need to be given.
-      def coinbase data = nil
+      def coinbase(data = nil)
         @coinbase_data = data || OpenSSL::Random.random_bytes(32)
         @prev_out_hash = "\x00" * 32
-        @prev_out_index = 4294967295
+        @prev_out_index = 4_294_967_295
       end
 
       # Create the txin according to specified values
@@ -440,21 +462,38 @@ module Bitcoin
         @txin
       end
 
-      def has_multiple_keys?
+      def multiple_keys?
         @key.is_a?(Array)
       end
 
-      def has_keys?
-        @key && (has_multiple_keys? ? @key.all?(&:priv) : @key.priv)
+      def has_multiple_keys? # rubocop:disable Style/PredicateName
+        warn '[DEPRECATION] `TxInBuilder.has_multiple_keys?` is deprecated. ' \
+             'Use `multiple_keys?` instaed.'
+        multiple_keys?
       end
 
-      def is_witness_v0_keyhash?
+      def keys?
+        @key && (multiple_keys? ? @key.all?(&:priv) : @key.priv)
+      end
+
+      def has_keys? # rubocop:disable Style/PredicateName
+        warn '[DEPRECATION] `TxInBuilder.has_keys?` is deprecated. Use `keys?` instead.'
+        keys?
+      end
+
+      def witness_v0_keyhash?
         @prev_out_script && Script.new(@prev_out_script).is_witness_v0_keyhash?
       end
 
+      def is_witness_v0_keyhash? # rubocop:disable Style/PredicateName
+        warn '[DEPRECATION] `TxInBuilder.is_witness_v0_keyhash?` is deprecated. ' \
+             'Use `witness_v0_keyhash?` instead.'
+        witness_v0_keyhash?
+      end
+
       def sign(sig_hash)
-        if has_multiple_keys?
-          @key.map {|k| k.sign(sig_hash) }
+        if multiple_keys?
+          @key.map { |k| k.sign(sig_hash) }
         else
           @key.sign(sig_hash)
         end
@@ -472,14 +511,14 @@ module Bitcoin
 
       # Script type (:pubkey, :address/hash160, :multisig).
       # Defaults to :address.
-      def type type
+      def type(type)
         @type = type.to_sym
       end
 
       # Recipient(s) of the script.
       # Depending on the #type, this should be an address, a hash160 pubkey,
       # or an array of multisig pubkeys.
-      def recipient *data
+      def recipient(*data)
         @script, @redeem_script = *Script.send("to_#{@type}_script", *data)
       end
     end
@@ -505,23 +544,24 @@ module Bitcoin
       end
 
       # Set output value (in base units / "satoshis")
-      def value value
+      def value(value)
         @txout.value = value
       end
 
       # Set recipient address and script type (defaults to :address).
-      def to recipient, type = :address
-        @txout.pk_script, @txout.redeem_script = *Bitcoin::Script.send("to_#{type}_script", *recipient)
+      def to(recipient, type = :address)
+        @txout.pk_script, @txout.redeem_script = *Bitcoin::Script.send(
+          "to_#{type}_script", *recipient
+        )
       end
 
       # Add a script to the output (see ScriptBuilder).
-      def script &block
+      def script
         c = ScriptBuilder.new
         yield c
-        @txout.pk_script, @txout.redeem_script = c.script, c.redeem_script
+        @txout.pk_script = c.script
+        @txout.redeem_script = c.redeem_script
       end
-
     end
-
   end
 end

--- a/lib/bitcoin/connection.rb
+++ b/lib/bitcoin/connection.rb
@@ -6,7 +6,7 @@ require 'bitcoin'
 require 'resolv'
 
 module Bitcoin
-
+  # Handle messages received from node
   module ConnectionHandler
     def on_inv_transaction(hash)
       p ['inv transaction', hash.hth]
@@ -38,13 +38,13 @@ module Bitcoin
 
     def on_block(block)
       p ['block', block.hash]
-      #p block.payload.each_byte.map{|i| "%02x" % [i] }.join(" ")
-      #puts block.to_json
+      # p block.payload.each_byte.map{|i| "%02x" % [i] }.join(" ")
+      # puts block.to_json
     end
 
     def on_version(version)
       p [@sockaddr, 'version', version, version.time - Time.now.to_i]
-      send_data( Protocol.verack_pkt )
+      send_data(Protocol.verack_pkt)
     end
 
     def on_verack
@@ -59,17 +59,17 @@ module Bitcoin
     end
 
     def query_blocks
-      start = ("\x00"*32)
-      stop  = ("\x00"*32)
-      pkt = Protocol.pkt("getblocks", "\x00" + start + stop )
+      start = ("\x00" * 32)
+      stop  = ("\x00" * 32)
+      pkt = Protocol.pkt('getblocks', "\x00" + start + stop)
       send_data(pkt)
     end
 
     def on_handshake_begin
-      block   = 127953
-      from    = "127.0.0.1:8333"
+      block   = 127_953
+      from    = '127.0.0.1:8333'
       from_id = Bitcoin::Protocol::Uniq
-      to      = @sockaddr.reverse.join(":")
+      to      = @sockaddr.reverse.join(':')
       # p "==", from_id, from, to, block
       pkt = Protocol.version_pkt(from_id, from, to, block)
       p ['sending version pkt', pkt]
@@ -77,19 +77,19 @@ module Bitcoin
     end
   end
 
-
+  # Establish connection to node
   class Connection < EM::Connection
     include ConnectionHandler
 
     def initialize(host, port, connections)
       @sockaddr = [port, host]
       @connections = connections
-      @parser = Bitcoin::Protocol::Parser.new( self )
+      @parser = Bitcoin::Protocol::Parser.new(self)
     end
 
     def post_init
       p ['connected', @sockaddr]
-      EM.schedule{ on_handshake_begin }
+      EM.schedule { on_handshake_begin }
     end
 
     def receive_data(data)
@@ -107,24 +107,21 @@ module Bitcoin
 
     def self.connect_random_from_dns(connections)
       seeds = Bitcoin.network[:dns_seeds]
-      if seeds.any?
-        host = Resolv::DNS.new.getaddresses(seeds.sample).map {|a| a.to_s}.sample
-        connect(host, Bitcoin::network[:default_port], connections)
-      else
-        raise "No DNS seeds available. Provide IP, configure seeds, or use different network."
+      if seeds.empty?
+        raise 'No DNS seeds available. Provide IP, configure seeds, or use different network.'
       end
+
+      host = Resolv::DNS.new.getaddresses(seeds.sample).map(&:to_s).sample
+      connect(host, Bitcoin.network[:default_port], connections)
     end
   end
 end
 
-
-if $0 == __FILE__
+if $PROGRAM_NAME == __FILE__
   EM.run do
-
     connections = []
-    #Bitcoin::Connection.connect('127.0.0.1', 8333, connections)
-    #Bitcoin::Connection.connect('217.157.1.202', 8333, connections)
+    # Bitcoin::Connection.connect('127.0.0.1', 8333, connections)
+    # Bitcoin::Connection.connect('217.157.1.202', 8333, connections)
     Bitcoin::Connection.connect_random_from_dns(connections)
-
   end
 end

--- a/lib/bitcoin/contracthash.rb
+++ b/lib/bitcoin/contracthash.rb
@@ -1,43 +1,39 @@
-#
-# Ruby port of https://github.com/Blockstream/contracthashtool
-#
-
 module Bitcoin
+  # Ruby port of https://github.com/Blockstream/contracthashtool
   module ContractHash
-
-    HMAC_DIGEST = OpenSSL::Digest.new("SHA256")
-    EC_GROUP = OpenSSL::PKey::EC::Group.new("secp256k1")
+    HMAC_DIGEST = OpenSSL::Digest.new('SHA256')
+    EC_GROUP = OpenSSL::PKey::EC::Group.new('secp256k1')
 
     def self.hmac(pubkey, data)
       OpenSSL::HMAC.hexdigest(HMAC_DIGEST, pubkey, data)
     end
 
     # generate a contract address
-    def self.generate(redeem_script_hex, payee_address_or_ascii, nonce_hex=nil)
-      redeem_script = Bitcoin::Script.new([redeem_script_hex].pack("H*"))
-      raise "only multisig redeem scripts are currently supported" unless redeem_script.is_multisig?
+    def self.generate(redeem_script_hex, payee_address_or_ascii, nonce_hex = nil)
+      redeem_script = Bitcoin::Script.new([redeem_script_hex].pack('H*'))
+      raise 'only multisig redeem scripts are currently supported' unless redeem_script.is_multisig?
       nonce_hex, data = compute_data(payee_address_or_ascii, nonce_hex)
 
       derived_keys = []
       redeem_script.get_multisig_pubkeys.each do |pubkey|
         tweak = hmac(pubkey, data).to_i(16)
-        raise "order exceeded, pick a new nonce" if tweak >= EC_GROUP.order.to_i
+        raise 'order exceeded, pick a new nonce' if tweak >= EC_GROUP.order.to_i
         tweak = OpenSSL::BN.new(tweak.to_s)
 
-        key = Bitcoin::Key.new(nil, pubkey.unpack("H*")[0])
+        key = Bitcoin::Key.new(nil, pubkey.unpack('H*')[0])
         key = key.instance_variable_get(:@key)
         point = EC_GROUP.generator.mul(tweak).ec_add(key.public_key).to_bn.to_i
-        raise "infinity" if point == 1/0.0
+        raise 'infinity' if point == 1 / 0.0
 
         key = Bitcoin::Key.new(nil, point.to_s(16))
-        key.instance_eval{ @pubkey_compressed = true }
+        key.instance_eval { @pubkey_compressed = true }
         derived_keys << key.pub
       end
 
       m = redeem_script.get_signatures_required
       p2sh_script, redeem_script = Bitcoin::Script.to_p2sh_multisig_script(m, *derived_keys)
 
-      [ nonce_hex, redeem_script.unpack("H*")[0], Bitcoin::Script.new(p2sh_script).get_p2sh_address ]
+      [nonce_hex, redeem_script.unpack('H*')[0], Bitcoin::Script.new(p2sh_script).get_p2sh_address]
     end
 
     # claim a contract
@@ -45,32 +41,32 @@ module Bitcoin
       key = Bitcoin::Key.from_base58(private_key_wif)
       data = compute_data(payee_address_or_ascii, nonce_hex)[1]
 
-      pubkey = [key.pub].pack("H*")
+      pubkey = [key.pub].pack('H*')
       tweak = hmac(pubkey, data).to_i(16)
-      raise "order exceeded, verify parameters" if tweak >= EC_GROUP.order.to_i
+      raise 'order exceeded, verify parameters' if tweak >= EC_GROUP.order.to_i
 
       derived_key = (tweak + key.priv.to_i(16)) % EC_GROUP.order.to_i
-      raise "zero" if derived_key == 0
+      raise 'zero' if derived_key.zero?
 
       Bitcoin::Key.new(derived_key.to_s(16))
     end
 
     # compute HMAC data
     def self.compute_data(address_or_ascii, nonce_hex)
-      nonce = nonce_hex ? [nonce_hex].pack("H32") : SecureRandom.random_bytes(16)
+      nonce = nonce_hex ? [nonce_hex].pack('H32') : SecureRandom.random_bytes(16)
       if Bitcoin.valid_address?(address_or_ascii)
         address_type = case Bitcoin.address_type(address_or_ascii)
-                       when :hash160;  'P2PH'
-                       when :p2sh;     'P2SH'
+                       when :hash160 then  'P2PH'
+                       when :p2sh then     'P2SH'
                        else
                          raise "unsupported address type #{address_type}"
                        end
-        contract_bytes = [ Bitcoin.hash160_from_address(address_or_ascii) ].pack("H*")
+        contract_bytes = [Bitcoin.hash160_from_address(address_or_ascii)].pack('H*')
       else
-        address_type = "TEXT"
+        address_type = 'TEXT'
         contract_bytes = address_or_ascii
       end
-      [ nonce.unpack("H*")[0], address_type + nonce + contract_bytes ]
+      [nonce.unpack('H*')[0], address_type + nonce + contract_bytes]
     end
   end
 end

--- a/lib/bitcoin/dogecoin.rb
+++ b/lib/bitcoin/dogecoin.rb
@@ -1,97 +1,99 @@
 # encoding: ascii-8bit
 
-# This module includes (almost) everything necessary to add dogecoin support
-# to bitcoin-ruby. When switching to a :dogecoin network, it will load its
-# functionality into the Script class.
-# The only things not included here should be parsing the AuxPow, which is
-# done in Protocol::Block directly, and passing the txout to #store_doge from
-# the storage backend.
-module Bitcoin::Dogecoin
+module Bitcoin
+  # This module includes (almost) everything necessary to add dogecoin support
+  # to bitcoin-ruby. When switching to a :dogecoin network, it will load its
+  # functionality into the Script class.
+  # The only things not included here should be parsing the AuxPow, which is
+  # done in Protocol::Block directly, and passing the txout to #store_doge from
+  # the storage backend.
+  module Dogecoin
+    def self.load
+      Bitcoin::Util.class_eval { include Util }
+    end
 
-  def self.load
-    Bitcoin::Util.class_eval { include Util }
-  end
+    # fixed reward past the 600k block
+    POST_600K_REWARD = 10_000 * Bitcoin::COIN
 
-  # fixed reward past the 600k block
-  POST_600K_REWARD = 10000 * Bitcoin::COIN
-
-  # Dogecoin-specific Script methods for parsing and creating of dogecoin scripts,
-  # as well as methods to extract address, doge_hash, doge and value.
-  module Util
-
-    def self.included(base)
-      base.constants.each {|c| const_set(c, base.const_get(c)) unless constants.include?(c) }
-      base.class_eval do
-
-        def block_creation_reward(block_height)
-          if block_height < Bitcoin.network[:difficulty_change_block]
-            # Dogecoin early rewards were random, using part of the hash of the
-            # previous block as the seed for the Mersenne Twister algorithm.
-            # Given we don't have previous block hash available, and this value is
-            # functionally a maximum (not exact value), I'm using the maximum the random
-            # reward generator can produce and calling it good enough.
-            Bitcoin.network[:reward_base] / (2 ** (block_height / Bitcoin.network[:reward_halving].to_f).floor) * 2
-          elsif block_height < 600000
-            Bitcoin.network[:reward_base] / (2 ** (block_height / Bitcoin.network[:reward_halving].to_f).floor)
-          else
-            POST_600K_REWARD
-          end
-        end
-        
-        def block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
-          new_difficulty_protocol = (prev_height + 1) >= Bitcoin.network[:difficulty_change_block]
-
-          # target interval for block interval in seconds
-          retarget_time = Bitcoin.network[:retarget_time]
-
-          if new_difficulty_protocol
-            # what is the ideal interval between the blocks
-            retarget_time = Bitcoin.network[:retarget_time_new]
-          end
-
-          # actual time elapsed since last retarget
-          actual_time = prev_block_time - last_retarget_time
-
-          if new_difficulty_protocol
-            # DigiShield implementation - thanks to RealSolid & WDC for this code
-            # We round always towards zero to match the C++ version
-            if actual_time < retarget_time
-              actual_time = retarget_time + ((actual_time - retarget_time) / 8.0).ceil
+    # Dogecoin-specific Script methods for parsing and creating of dogecoin scripts,
+    # as well as methods to extract address, doge_hash, doge and value.
+    module Util
+      # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+      def self.included(base)
+        base.constants.each { |c| const_set(c, base.const_get(c)) unless constants.include?(c) }
+        base.class_eval do
+          def block_creation_reward(block_height)
+            reward_scaler = 2**(block_height / Bitcoin.network[:reward_halving].to_f).floor
+            if block_height < Bitcoin.network[:difficulty_change_block]
+              # Dogecoin early rewards were random, using part of the hash of the
+              # previous block as the seed for the Mersenne Twister algorithm.
+              # Given we don't have previous block hash available, and this value is
+              # functionally a maximum (not exact value), I'm using the maximum the random
+              # reward generator can produce and calling it good enough.
+              Bitcoin.network[:reward_base] / reward_scaler * 2
+            elsif block_height < 600_000
+              Bitcoin.network[:reward_base] / reward_scaler
             else
-              actual_time = retarget_time + ((actual_time - retarget_time) / 8.0).floor
+              POST_600K_REWARD
             end
-            # amplitude filter - thanks to daft27 for this code
-            min = retarget_time - (retarget_time/4)
-            max = retarget_time + (retarget_time/2)
-          elsif prev_height+1 > 10000
-            min = retarget_time / 4
-            max = retarget_time * 4
-          elsif prev_height+1 > 5000
-            min = retarget_time / 8
-            max = retarget_time * 4
-          else
-            min = retarget_time / 16
-            max = retarget_time * 4
           end
 
-          actual_time = min if actual_time < min
-          actual_time = max if actual_time > max
+          def block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+            new_difficulty_protocol = (prev_height + 1) >= Bitcoin.network[:difficulty_change_block]
 
-          # It could be a bit confusing: we are adjusting difficulty of the previous block, while logically
-          # we should use difficulty of the previous 2016th block ("first")
+            # target interval for block interval in seconds
+            retarget_time = Bitcoin.network[:retarget_time]
 
-          prev_target = decode_compact_bits(prev_block_bits).to_i(16)
+            if new_difficulty_protocol
+              # what is the ideal interval between the blocks
+              retarget_time = Bitcoin.network[:retarget_time_new]
+            end
 
-          new_target = prev_target * actual_time / retarget_time
-          if new_target < Bitcoin.decode_compact_bits(Bitcoin.network[:proof_of_work_limit]).to_i(16)
-            encode_compact_bits(new_target.to_s(16))
-          else
-            Bitcoin.network[:proof_of_work_limit]
+            # actual time elapsed since last retarget
+            actual_time = prev_block_time - last_retarget_time
+
+            if new_difficulty_protocol
+              # DigiShield implementation - thanks to RealSolid & WDC for this code
+              # We round always towards zero to match the C++ version
+              actual_time = if actual_time < retarget_time
+                              retarget_time + ((actual_time - retarget_time) / 8.0).ceil
+                            else
+                              retarget_time + ((actual_time - retarget_time) / 8.0).floor
+                            end
+              # amplitude filter - thanks to daft27 for this code
+              min = retarget_time - (retarget_time / 4)
+              max = retarget_time + (retarget_time / 2)
+            elsif prev_height + 1 > 10_000
+              min = retarget_time / 4
+              max = retarget_time * 4
+            elsif prev_height + 1 > 5000
+              min = retarget_time / 8
+              max = retarget_time * 4
+            else
+              min = retarget_time / 16
+              max = retarget_time * 4
+            end
+
+            actual_time = min if actual_time < min
+            actual_time = max if actual_time > max
+
+            # It could be a bit confusing: we are adjusting difficulty of the previous block,
+            # while logically we should use difficulty of the previous 2016th block ("first")
+
+            prev_target = decode_compact_bits(prev_block_bits).to_i(16)
+
+            new_target = prev_target * actual_time / retarget_time
+            if new_target < Bitcoin.decode_compact_bits(
+              Bitcoin.network[:proof_of_work_limit]
+            ).to_i(16)
+              encode_compact_bits(new_target.to_s(16))
+            else
+              Bitcoin.network[:proof_of_work_limit]
+            end
           end
         end
       end
+      # rubocop:enable CyclomaticComplexity,PerceivedComplexity
     end
-
   end
-
 end


### PR DESCRIPTION
This is an incremental patch to get the bitcoin-ruby codebase conformed to a uniform code quality standard using rubocop.

Fixed files:
- `/lib/bitcoin/bech32.rb`
- `/lib/bitcoin/bloom_filter.rb`
- `/lib/bitcoin/builder.rb`
- `/lib/bitcoin/connection.rb`
- `/lib/bitcoin/contracthash.rb`
- `/lib/bitcoin/dogecoin.rb`

Updated Rubocop configs:
- `Metrics/BlockLength` maximum of 50
- `Metrics/ModuleLength` maximum of 500