### PR TITLE
Rubocop fixes for remaining utils

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,8 @@ Metrics/BlockLength:
 
 Metrics/ClassLength:
   Max: 500
+  Exclude:
+    - 'lib/bitcoin/script.rb'
 
 Metrics/CyclomaticComplexity:
   Max: 10

--- a/lib/bitcoin.rb
+++ b/lib/bitcoin.rb
@@ -1,18 +1,18 @@
 # encoding: ascii-8bit
-# Bitcoin Utils and Network Protocol in Ruby.
 
 require 'digest/sha2'
 require 'digest/rmd160'
 require 'openssl'
 require 'securerandom'
 
+# Bitcoin Utils and Network Protocol in Ruby.
 module Bitcoin
   # Determine the integer class to use. In older versions of ruby (< 2.4.0) the
   # integer class is called Fixnum. In newer version (>= 2.4.0) Fixnum was
   # deprecated in favor of a unification of Fixnum and BigInteger named Integer.
   # Since this project strivers for backwards-compatability, we determine the
   # appropriate class to use at initialization.
-  # 
+  #
   # This avoids annoying deprecation warnings on newer versions for ourselves
   # and library consumers.
   Integer =
@@ -32,42 +32,51 @@ module Bitcoin
   autoload :ExtKey,     'bitcoin/ext_key'
   autoload :ExtPubkey,  'bitcoin/ext_key'
   autoload :Builder,    'bitcoin/builder'
-  autoload :BloomFilter,'bitcoin/bloom_filter'
+  autoload :BloomFilter, 'bitcoin/bloom_filter'
 
   autoload :Dogecoin,   'bitcoin/dogecoin'
   autoload :Litecoin,   'bitcoin/litecoin'
 
-  autoload :ContractHash,   'bitcoin/contracthash'
+  autoload :ContractHash, 'bitcoin/contracthash'
 
+  # Trezor hardware wallet
   module Trezor
-    autoload :Mnemonic,   'bitcoin/trezor/mnemonic'
+    autoload :Mnemonic, 'bitcoin/trezor/mnemonic'
   end
 
-
+  # General Bitcoin utilities
   module Util
+    def address_version
+      Bitcoin.network[:address_version]
+    end
 
-    def address_version; Bitcoin.network[:address_version]; end
-    def p2sh_version; Bitcoin.network[:p2sh_version]; end
+    def p2sh_version
+      Bitcoin.network[:p2sh_version]
+    end
 
     # hash160 is a 20 bytes (160bits) rmd610-sha256 hexdigest.
     def hash160(hex)
-      bytes = [hex].pack("H*")
+      bytes = [hex].pack('H*')
       Digest::RMD160.hexdigest Digest::SHA256.digest(bytes)
     end
 
     # checksum is a 4 bytes sha256-sha256 hexdigest.
     def checksum(hex)
-      b = [hex].pack("H*") # unpack hex
-      Digest::SHA256.hexdigest( Digest::SHA256.digest(b) )[0...8]
+      b = [hex].pack('H*') # unpack hex
+      Digest::SHA256.hexdigest(Digest::SHA256.digest(b))[0...8]
     end
 
     # verify base58 checksum for given +base58+ data.
     def base58_checksum?(base58)
-      hex = decode_base58(base58) rescue nil
+      hex = begin
+              decode_base58(base58)
+            rescue
+              nil
+            end
       return false unless hex
-      checksum( hex[0...42] ) == hex[-8..-1]
+      checksum(hex[0...42]) == hex[-8..-1]
     end
-    alias :address_checksum? :base58_checksum?
+    alias address_checksum? base58_checksum?
 
     # check if given +address+ is valid.
     # this means having a correct version byte, length and checksum.
@@ -100,22 +109,31 @@ module Bitcoin
     end
 
     # get type of given +address+.
+    # rubocop:disable CyclomaticComplexity, PerceivedComplexity
     def address_type(address)
-      segwit_decoded = decode_segwit_address(address) rescue nil
+      segwit_decoded = begin
+                         decode_segwit_address(address)
+                       rescue
+                         nil
+                       end
       if segwit_decoded
         witness_version, witness_program_hex = segwit_decoded
-        witness_program = [witness_program_hex].pack("H*")
+        witness_program = [witness_program_hex].pack('H*')
 
-        if witness_version == 0 && witness_program.bytesize == 20
+        if witness_version.zero? && witness_program.bytesize == 20
           return :witness_v0_keyhash
         end
 
-        if witness_version == 0 && witness_program.bytesize == 32
+        if witness_version.zero? && witness_program.bytesize == 32
           return :witness_v0_scripthash
         end
       end
 
-      hex = decode_base58(address) rescue nil
+      hex = begin
+              decode_base58(address)
+            rescue
+              nil
+            end
       if hex && hex.bytesize == 50 && address_checksum?(address)
         # Litecoin updates the P2SH version byte, and this method should recognize both.
         p2sh_versions = [p2sh_version]
@@ -133,9 +151,10 @@ module Bitcoin
 
       nil
     end
+    # rubocop:enable CyclomaticComplexity, PerceivedComplexity
 
     def sha256(hex)
-      Digest::SHA256.hexdigest([hex].pack("H*"))
+      Digest::SHA256.hexdigest([hex].pack('H*'))
     end
 
     def hash160_to_address(hex)
@@ -152,60 +171,63 @@ module Bitcoin
     end
 
     def pubkey_to_address(pubkey)
-      hash160_to_address( hash160(pubkey) )
+      hash160_to_address(hash160(pubkey))
     end
 
     def pubkeys_to_p2sh_multisig_address(m, *pubkeys)
       redeem_script = Bitcoin::Script.to_p2sh_multisig_script(m, *pubkeys).last
-      return Bitcoin.hash160_to_p2sh_address(Bitcoin.hash160(redeem_script.hth)), redeem_script
+      [Bitcoin.hash160_to_p2sh_address(Bitcoin.hash160(redeem_script.hth)), redeem_script]
     end
-
 
     def encode_segwit_address(version, program_hex)
       hrp = Bitcoin.network[:bech32_hrp]
-      raise "Invalid network" if hrp.nil?
+      raise 'Invalid network' if hrp.nil?
 
-      program = [program_hex].pack("H*")
+      program = [program_hex].pack('H*')
 
       return nil if version > 16
       length = program.size
-      return nil if version == 0 && length != 20 && length != 32
+      return nil if version.zero? && length != 20 && length != 32
       return nil if length < 2 || length > 40
 
-      data = [ version ] + Bitcoin::Bech32.convert_bits(program.unpack("C*"), from_bits: 8, to_bits: 5, pad: true)
+      data = [version] + Bitcoin::Bech32.convert_bits(
+        program.unpack('C*'), from_bits: 8, to_bits: 5, pad: true
+      )
 
       address = Bitcoin::Bech32.encode(hrp, data)
 
-      return address.nil? ? nil : address
+      address.nil? ? nil : address
     end
 
+    # rubocop:disable CyclomaticComplexity, PerceivedComplexity
     def decode_segwit_address(address)
       hrp = Bitcoin.network[:bech32_hrp]
       return nil if hrp.nil?
 
-      actual_hrp, data  = Bitcoin::Bech32.decode(address)
+      actual_hrp, data = Bitcoin::Bech32.decode(address)
 
       return nil if actual_hrp.nil?
       length = data.size
-      return nil if length == 0 || length > 65
+      return nil if length.zero? || length > 65
       return nil if hrp != actual_hrp
       return nil if data[0] > 16
-
 
       program = Bitcoin::Bech32.convert_bits(data[1..-1], from_bits: 5, to_bits: 8, pad: false)
       return nil if program.nil?
 
       length = program.size
       return nil if length < 2 || length > 40
-      return nil if data[0] == 0 && length != 20 && length != 32
+      return nil if data[0].zero? && length != 20 && length != 32
 
-      program_hex = program.pack("C*").unpack("H*").first
-      return [data[0], program_hex]
+      program_hex = program.pack('C*').unpack('H*').first
+      [data[0], program_hex]
     end
+    # rubocop:enable CyclomaticComplexity, PerceivedComplexity
 
-    def int_to_base58(int_val, leading_zero_bytes=0)
-      alpha = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-      base58_val, base = '', alpha.size
+    def int_to_base58(int_val, _leading_zero_bytes = 0)
+      alpha = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+      base58_val = ''
+      base = alpha.size
       while int_val > 0
         int_val, remainder = int_val.divmod(base)
         base58_val = alpha[remainder] + base58_val
@@ -214,51 +236,55 @@ module Bitcoin
     end
 
     def base58_to_int(base58_val)
-      alpha = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-      int_val, base = 0, alpha.size
-      base58_val.reverse.each_char.with_index do |char,index|
-        raise ArgumentError, 'Value not a valid Base58 String.' unless char_index = alpha.index(char)
-        int_val += char_index*(base**index)
+      alpha = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'
+      int_val = 0
+      base = alpha.size
+      base58_val.reverse.each_char.with_index do |char, index|
+        char_index = alpha.index(char)
+        raise ArgumentError, 'Value not a valid Base58 String.' unless char_index
+        int_val += char_index * (base**index)
       end
       int_val
     end
 
     def encode_base58(hex)
-      leading_zero_bytes  = (hex.match(/^([0]+)/) ? $1 : '').size / 2
-      ("1"*leading_zero_bytes) + int_to_base58( hex.to_i(16) )
+      leading_zero_bytes = (hex =~ /^([0]+)/ ? Regexp.last_match(1) : '').size / 2
+      ('1' * leading_zero_bytes) + int_to_base58(hex.to_i(16))
     end
 
     def decode_base58(base58_val)
-      s = base58_to_int(base58_val).to_s(16); s = (s.bytesize.odd? ? '0'+s : s)
+      s = base58_to_int(base58_val).to_s(16)
+      s = (s.bytesize.odd? ? '0' + s : s)
       s = '' if s == '00'
-      leading_zero_bytes = (base58_val.match(/^([1]+)/) ? $1 : '').size
-      s = ("00"*leading_zero_bytes) + s  if leading_zero_bytes > 0
+      leading_zero_bytes = (base58_val =~ /^([1]+)/ ? Regexp.last_match(1) : '').size
+      s = ('00' * leading_zero_bytes) + s if leading_zero_bytes > 0
       s
     end
-    alias_method :base58_to_hex, :decode_base58
+    alias base58_to_hex decode_base58
 
     # target compact bits (int) to bignum hex
+    # rubocop:disable PerceivedComplexity
     def decode_compact_bits(bits)
+      bytes = Array.new(size = ((bits >> 24) & 255), 0)
       if Bitcoin.network_project == :dogecoin
-        bytes = Array.new(size=((bits >> 24) & 255), 0)
         bytes[0] = (bits >> 16) & 0x7f if size >= 1
-        bytes[1] = (bits >>  8) & 255 if size >= 2
-        bytes[2] = (bits      ) & 255 if size >= 3
-        target = bytes.pack("C*").unpack("H*")[0].rjust(64, '0')
+        bytes[1] = (bits >> 8) & 255 if size >= 2
+        bytes[2] = bits & 255 if size >= 3
+        target = bytes.pack('C*').unpack('H*')[0].rjust(64, '0')
         # Bit number 24 represents the sign
         if (bits & 0x00800000) != 0
-          "-" + target
+          '-' + target
         else
           target
         end
       else
-        bytes = Array.new(size=((bits >> 24) & 255), 0)
         bytes[0] = (bits >> 16) & 255 if size >= 1
-        bytes[1] = (bits >>  8) & 255 if size >= 2
-        bytes[2] = (bits      ) & 255 if size >= 3
-        bytes.pack("C*").unpack("H*")[0].rjust(64, '0')
+        bytes[1] = (bits >> 8) & 255 if size >= 2
+        bytes[2] = bits & 255 if size >= 3
+        bytes.pack('C*').unpack('H*')[0].rjust(64, '0')
       end
     end
+    # rubocop:enable PerceivedComplexity
 
     # target bignum hex to compact bits (int)
     def encode_compact_bits(target)
@@ -266,41 +292,41 @@ module Bitcoin
       size = bytes.size - 4
       nbits = size << 24
       nbits |= (bytes[4] << 16) if size >= 1
-      nbits |= (bytes[5] <<  8) if size >= 2
-      nbits |= (bytes[6]      ) if size >= 3
+      nbits |= (bytes[5] << 8) if size >= 2
+      nbits |= (bytes[6]) if size >= 3
       nbits
     end
 
     def decode_target(target_bits)
       case target_bits
       when Bitcoin::Integer
-        [ decode_compact_bits(target_bits).to_i(16), target_bits ]
+        [decode_compact_bits(target_bits).to_i(16), target_bits]
       when String
-        [ target_bits.to_i(16), encode_compact_bits(target_bits) ]
+        [target_bits.to_i(16), encode_compact_bits(target_bits)]
       end
     end
 
     def bitcoin_elliptic_curve
-      ::OpenSSL::PKey::EC.new("secp256k1")
+      ::OpenSSL::PKey::EC.new('secp256k1')
     end
 
     def generate_key
       key = bitcoin_elliptic_curve.generate_key
-      inspect_key( key )
+      inspect_key(key)
     end
 
     def inspect_key(key)
-      [ key.private_key_hex, key.public_key_hex ]
+      [key.private_key_hex, key.public_key_hex]
     end
 
     def generate_address
       prvkey, pubkey = generate_key
-      [ pubkey_to_address(pubkey), prvkey, pubkey, hash160(pubkey) ]
+      [pubkey_to_address(pubkey), prvkey, pubkey, hash160(pubkey)]
     end
 
     def bitcoin_hash(hex)
       Digest::SHA256.digest(
-        Digest::SHA256.digest( [hex].pack("H*").reverse )
+        Digest::SHA256.digest([hex].pack('H*').reverse)
       ).reverse.bth
     end
 
@@ -308,52 +334,57 @@ module Bitcoin
       Digest::SHA256.digest(Digest::SHA256.digest(bytes))
     end
 
-    def bitcoin_mrkl(a, b); bitcoin_hash(b + a); end
-
-    def block_hash(prev_block, mrkl_root, time, bits, nonce, ver)
-      h = "%08x%08x%08x%064s%064s%08x" %
-            [nonce, bits, time, mrkl_root, prev_block, ver]
-      bitcoin_hash(h)
+    def bitcoin_mrkl(a, b)
+      bitcoin_hash(b + a)
     end
 
+    # rubocop:disable Metrics/ParameterLists
+    def block_hash(prev_block, mrkl_root, time, bits, nonce, ver)
+      h = format('%08x%08x%08x%064s%064s%08x', nonce, bits, time, mrkl_root, prev_block, ver)
+      bitcoin_hash(h)
+    end
+    # rubocop:enable Metrics/ParameterLists
+
     def litecoin_hash(hex)
-      bytes = [hex].pack("H*").reverse
+      bytes = [hex].pack('H*').reverse
       begin
-        require "scrypt" unless defined?(::SCrypt)
+        require 'scrypt' unless defined?(::SCrypt)
         hash = SCrypt::Engine.__sc_crypt(bytes, bytes, 1024, 1, 1, 32)
       rescue LoadError
         hash = Litecoin::Scrypt.scrypt_1024_1_1_256_sp(bytes)
       end
-      hash.reverse.unpack("H*")[0]
+      hash.reverse.unpack('H*')[0]
     end
 
+    # rubocop:disable Metrics/ParameterLists
     def block_scrypt_hash(prev_block, mrkl_root, time, bits, nonce, ver)
-      h = "%08x%08x%08x%064s%064s%08x" %
-            [nonce, bits, time, mrkl_root, prev_block, ver]
+      h = format('%08x%08x%08x%064s%064s%08x', nonce, bits, time, mrkl_root, prev_block, ver)
       litecoin_hash(h)
     end
+    # rubocop:enable Metrics/ParameterLists
 
     # get merkle tree for given +tx+ list.
     def hash_mrkl_tree(tx)
-      return [nil]  if tx != tx.uniq
-      chunks = [ tx.dup ]
+      return [nil] if tx != tx.uniq
+      chunks = [tx.dup]
       while chunks.last.size >= 2
-        chunks << chunks.last.each_slice(2).map {|a, b| bitcoin_mrkl( a, b || a ) }
+        chunks << chunks.last.each_slice(2).map { |a, b| bitcoin_mrkl(a, b || a) }
       end
       chunks.flatten
     end
 
     # get merkle branch connecting given +target+ to the merkle root of +tx+ list
     def hash_mrkl_branch(tx, target)
-      return [ nil ]  if tx != tx.uniq
-      branch, chunks = [], [ tx.dup ]
+      return [nil] if tx != tx.uniq
+      branch = []
+      chunks = [tx.dup]
       while chunks.last.size >= 2
-        chunks << chunks.last.each_slice(2).map {|a, b|
-          hash = bitcoin_mrkl( a, b || a )
-          next hash  unless [a, b].include?(target)
+        chunks << chunks.last.each_slice(2).map do |a, b|
+          hash = bitcoin_mrkl(a, b || a)
+          next hash unless [a, b].include?(target)
           branch << (a == target ? (b || a) : a)
           target = hash
-        }
+        end
       end
       branch
     end
@@ -361,16 +392,16 @@ module Bitcoin
     # get merkle root from +branch+ and +target+.
     def mrkl_branch_root(branch, target, idx)
       branch.each do |hash|
-        a, b = *( idx & 1 == 0 ? [target, hash] : [hash, target] )
-        idx >>= 1;
-        target = bitcoin_mrkl( a, b )
+        a, b = *((idx & 1).zero? ? [target, hash] : [hash, target])
+        idx >>= 1
+        target = bitcoin_mrkl(a, b)
       end
       target
     end
 
     def sign_data(key, data)
       sig = nil
-      loop {
+      loop do
         sig = key.dsa_sign_asn1(data)
         sig = if Script.is_low_der_signature?(sig)
                 sig
@@ -378,18 +409,20 @@ module Bitcoin
                 Bitcoin::OpenSSL_EC.signature_to_low_s(sig)
               end
 
-        buf = sig + [Script::SIGHASH_TYPE[:all]].pack("C") # is_der_signature expects sig + sighash_type format
-        if Script.is_der_signature?(buf)
-          break
-        else
-          p ["Bitcoin#sign_data: invalid der signature generated, trying again.", data.unpack("H*")[0], sig.unpack("H*")[0]]
-        end
-      }
-      return sig
+        # is_der_signature expects sig + sighash_type format
+        buf = sig + [Script::SIGHASH_TYPE[:all]].pack('C')
+        break if Script.is_der_signature?(buf)
+        p [
+          'Bitcoin#sign_data: invalid der signature generated, trying again.',
+          data.unpack('H*')[0],
+          sig.unpack('H*')[0]
+        ]
+      end
+      sig
     end
 
     def verify_signature(hash, signature, public_key)
-      key  = bitcoin_elliptic_curve
+      key = bitcoin_elliptic_curve
       key.public_key = ::OpenSSL::PKey::EC::Point.from_hex(key.group, public_key)
       signature = Bitcoin::OpenSSL_EC.repack_der_signature(signature)
       if signature
@@ -401,11 +434,11 @@ module Bitcoin
       false
     end
 
-    def open_key(private_key, public_key=nil)
-      key  = bitcoin_elliptic_curve
+    def open_key(private_key, public_key = nil)
+      key = bitcoin_elliptic_curve
       key.private_key = ::OpenSSL::BN.from_hex(private_key)
       public_key = regenerate_public_key(private_key) unless public_key
-      key.public_key  = ::OpenSSL::PKey::EC::Point.from_hex(key.group, public_key)
+      key.public_key = ::OpenSSL::PKey::EC::Point.from_hex(key.group, public_key)
       key
     end
 
@@ -426,11 +459,19 @@ module Bitcoin
     def sign_message(private_key_hex, public_key_hex, message)
       hash = bitcoin_signed_message_hash(message)
       signature = OpenSSL_EC.sign_compact(hash, private_key_hex, public_key_hex)
-      { 'address' => pubkey_to_address(public_key_hex), 'message' => message, 'signature' => [ signature ].pack("m0") }
+      {
+        'address' => pubkey_to_address(public_key_hex),
+        'message' => message,
+        'signature' => [signature].pack('m0')
+      }
     end
 
     def verify_message(address, signature, message)
-      signature = signature.unpack("m0")[0] rescue nil # decode base64
+      signature = begin
+                    signature.unpack('m0')[0]
+                  rescue
+                    nil
+                  end # decode base64
       return false unless valid_address?(address)
       return false unless signature
       return false unless signature.bytesize == 65
@@ -441,7 +482,7 @@ module Bitcoin
 
     # block count when the next retarget will take place.
     def block_next_retarget(block_height)
-      (block_height + (RETARGET_INTERVAL-block_height.divmod(RETARGET_INTERVAL).last)) - 1
+      (block_height + (RETARGET_INTERVAL - block_height.divmod(RETARGET_INTERVAL).last)) - 1
     end
 
     # current difficulty as a multiple of the minimum difficulty (highest target).
@@ -449,8 +490,14 @@ module Bitcoin
       # max_target      = 0x00000000ffff0000000000000000000000000000000000000000000000000000
       # current_target  = Bitcoin.decode_compact_bits(target_nbits).to_i(16)
       # "%.7f" % (max_target / current_target.to_f)
-      bits, max_body, scaland = target_nbits, Math.log(0x00ffff), Math.log(256)
-      "%.7f" % Math.exp(max_body - Math.log(bits&0x00ffffff) + scaland * (0x1d - ((bits&0xff000000)>>24)))
+      bits = target_nbits
+      max_body = Math.log(0x00ffff)
+      scaland = Math.log(256)
+      format(
+        '%.7f',
+        Math.exp(max_body - Math.log(bits & 0x00ffffff) + \
+          scaland * (0x1d - ((bits & 0xff000000) >> 24)))
+      )
     end
 
     # Calculate new difficulty target. Note this takes in details of the preceeding
@@ -458,9 +505,10 @@ module Bitcoin
     #
     # prev_height is the height of the block before the retarget occurs
     # prev_block_time "time" field from the block before the retarget occurs
-    # prev_block_bits "bits" field from the block before the retarget occurs (target as a compact value)
+    # prev_block_bits "bits" field from the block before the retarget occurs
+    #   (target as a compact value)
     # last_retarget_time is the "time" field from the block when a retarget last occurred
-    def block_new_target(prev_height, prev_block_time, prev_block_bits, last_retarget_time)
+    def block_new_target(_prev_height, prev_block_time, prev_block_bits, last_retarget_time)
       # target interval - what is the ideal interval between the blocks
       retarget_time = Bitcoin.network[:retarget_time]
 
@@ -472,8 +520,8 @@ module Bitcoin
       actual_time = min if actual_time < min
       actual_time = max if actual_time > max
 
-      # It could be a bit confusing: we are adjusting difficulty of the previous block, while logically
-      # we should use difficulty of the previous retarget block
+      # It could be a bit confusing: we are adjusting difficulty of the previous block,
+      # while logically we should use difficulty of the previous retarget block
 
       prev_target = decode_compact_bits(prev_block_bits).to_i(16)
 
@@ -487,14 +535,17 @@ module Bitcoin
 
     # average number of hashes required to win a block with the current target. (nbits)
     def block_hashes_to_win(target_nbits)
-      current_target  = decode_compact_bits(target_nbits).to_i(16)
+      current_target = decode_compact_bits(target_nbits).to_i(16)
       0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff / current_target
     end
 
     # probability of a single hash solving a block with the current difficulty.
     def block_probability(target_nbits)
-      current_target  = decode_compact_bits(target_nbits).to_i(16)
-      "%.55f" % (current_target.to_f / 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+      current_target = decode_compact_bits(target_nbits).to_i(16)
+      format(
+        '%.55f',
+        (current_target.to_f / 0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
+      )
     end
 
     # average time to find a block in seconds with the current target. (nbits)
@@ -503,73 +554,65 @@ module Bitcoin
     end
 
     # average mining time (in days) using Mh/s to get btc
-    def block_average_mining_time(block_nbits, block_height, mega_hashes_per_second, target_btc=1.0)
+    def block_average_mining_time(
+      block_nbits, block_height, mega_hashes_per_second, target_btc = 1.0
+    )
       seconds = block_average_hashing_time(block_nbits, mega_hashes_per_second * 1_000_000)
       reward  = block_creation_reward(block_height) / COIN # satoshis to btc
-      (days = seconds / 60 / 60 / 24) * (target_btc / reward)
+      (seconds / 60 / 60 / 24) * (target_btc / reward)
     end
 
     # shows the total number of Bitcoins in circulation, reward era and reward in that era.
     def blockchain_total_btc(height)
-      reward, interval = Bitcoin.network[:reward_base], Bitcoin.network[:reward_halving]
+      reward = Bitcoin.network[:reward_base]
+      interval = Bitcoin.network[:reward_halving]
       total_btc = reward
-      reward_era, remainder = (height).divmod(interval)
-      reward_era.times{
+      reward_era, remainder = height.divmod(interval)
+      reward_era.times do
         total_btc += interval * reward
-        reward = reward / 2
-      }
+        reward /= 2
+      end
       total_btc += remainder * reward
-      [total_btc, reward_era+1, reward, height]
+      [total_btc, reward_era + 1, reward, height]
     end
 
     def block_creation_reward(block_height)
-      Bitcoin.network[:reward_base] / (2 ** (block_height / Bitcoin.network[:reward_halving].to_f).floor)
+      discount = block_height / Bitcoin.network[:reward_halving].to_f
+      Bitcoin.network[:reward_base] / 2**discount.floor
     end
   end
 
   extend Util
 
-  module  BinaryExtensions
+  # Binary helpers
+  module BinaryExtensions
     # bin-to-hex
-    def bth; unpack("H*")[0]; end
+    def bth
+      unpack('H*')[0]
+    end
+
     # hex-to-bin
-    def htb; [self].pack("H*"); end
-
-    def htb_reverse; htb.reverse; end
-    def hth; unpack("H*")[0]; end
-    def reverse_hth; reverse.hth; end
-  end
-
-  class ::String
-    include Bitcoin::BinaryExtensions
-  end
-
-
-  module ::OpenSSL
-    class BN
-      def self.from_hex(hex); new(hex, 16); end
-      def to_hex; to_i.to_s(16); end
-      def to_mpi; to_s(0).unpack("C*"); end
+    def htb
+      [self].pack('H*')
     end
-    class PKey::EC
-      def private_key_hex; private_key.to_hex.rjust(64, '0'); end
-      def public_key_hex;  public_key.to_hex.rjust(130, '0'); end
-      def pubkey_compressed?; public_key.group.point_conversion_form == :compressed; end
+
+    def htb_reverse
+      htb.reverse
     end
-    class PKey::EC::Point
-      def self.from_hex(group, hex)
-        new(group, BN.from_hex(hex))
-      end
-      def to_hex; to_bn.to_hex; end
-      def self.bn2mpi(hex) BN.from_hex(hex).to_mpi; end
-      def ec_add(point); self.class.new(group, OpenSSL::BN.from_hex(OpenSSL_EC.ec_add(self, point))); end
+
+    def hth
+      unpack('H*')[0]
+    end
+
+    def reverse_hth
+      reverse.hth
     end
   end
 
-  autoload :OpenSSL_EC, "bitcoin/ffi/openssl"
+  autoload :OpenSSL_EC, 'bitcoin/ffi/openssl'
 
-  autoload :Secp256k1, "bitcoin/ffi/secp256k1"
-  autoload :BitcoinConsensus, "bitcoin/ffi/bitcoinconsensus"
+  autoload :Secp256k1, 'bitcoin/ffi/secp256k1'
+  autoload :BitcoinConsensus, 'bitcoin/ffi/bitcoinconsensus'
 
   @network = :bitcoin
 
@@ -587,34 +630,38 @@ module Bitcoin
   end
 
   def self.network=(name)
-    raise "Network descriptor '#{name}' not found."  unless NETWORKS[name.to_sym]
+    raise "Network descriptor '#{name}' not found." unless NETWORKS[name.to_sym]
     @network_options = nil # clear cached parameters
     @network = name.to_sym
-    @network_project = network[:project] rescue nil
+    @network_project = begin
+                         network[:project]
+                       rescue
+                         nil
+                       end
     Dogecoin.load  if dogecoin? || dogecoin_testnet?
     Namecoin.load  if namecoin? && defined?(Namecoin)
     @network
   end
 
-  [:bitcoin, :namecoin, :litecoin, :dogecoin, :dogecoin_testnet].each do |n|
+  %i[bitcoin namecoin litecoin dogecoin dogecoin_testnet].each do |n|
     instance_eval "def #{n}?; network_project == :#{n}; end"
   end
-
 
   # maximum size of a block (in bytes)
   MAX_BLOCK_SIZE = 1_000_000
 
   # soft limit for new blocks
-  MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE/2
+  MAX_BLOCK_SIZE_GEN = MAX_BLOCK_SIZE / 2
 
   # maximum number of signature operations in a block
   MAX_BLOCK_SIGOPS = MAX_BLOCK_SIZE / 50
 
   # maximum number of orphan transactions to be kept in memory
-  MAX_ORPHAN_TRANSACTIONS = MAX_BLOCK_SIZE/100
+  MAX_ORPHAN_TRANSACTIONS = MAX_BLOCK_SIZE / 100
 
-  # Threshold for lock_time: below this value it is interpreted as block number, otherwise as UNIX timestamp.
-  LOCKTIME_THRESHOLD = 500000000 # Tue Nov  5 00:53:20 1985 UTC
+  # Threshold for lock_time: below this value it is interpreted as block number,
+  # otherwise as UNIX timestamp.
+  LOCKTIME_THRESHOLD = 500_000_000 # Tue Nov  5 00:53:20 1985 UTC
 
   # maximum integer value
   UINT32_MAX = 0xffffffff
@@ -627,33 +674,32 @@ module Bitcoin
   RETARGET_INTERVAL = 2016
   RETARGET = 2016 # deprecated constant
 
-
   # interval (in blocks) for mining reward reduction
   REWARD_DROP = 210_000
 
-  CENT =   1_000_000
+  CENT = 1_000_000
   COIN = 100_000_000
 
-  MIN_FEE_MODE     = [ :block, :relay, :send ]
+  MIN_FEE_MODE = %i[block relay send].freeze
 
-  NETWORKS = {
+  NETWORKS = { # rubocop:disable Style/MutableConstant
     bitcoin: {
       project: :bitcoin,
       magic_head: "\xF9\xBE\xB4\xD9",
       message_magic: "Bitcoin Signed Message:\n",
-      address_version: "00",
-      p2sh_version: "05",
-      privkey_version: "80",
-      extended_privkey_version: "0488ade4",
-      extended_pubkey_version: "0488b21e",
-      bech32_hrp: "bc",
+      address_version: '00',
+      p2sh_version: '05',
+      privkey_version: '80',
+      extended_privkey_version: '0488ade4',
+      extended_pubkey_version: '0488b21e',
+      bech32_hrp: 'bc',
       default_port: 8333,
-      protocol_version: 70001,
+      protocol_version: 70_001,
       coinbase_maturity: 100,
       reward_base: 50 * COIN,
       reward_halving: 210_000,
       retarget_interval: 2016,
-      retarget_time: 1209600, # 2 weeks
+      retarget_time: 1_209_600, # 2 weeks
       target_spacing: 600, # block interval
       max_money: 21_000_000 * COIN,
       min_tx_fee: 10_000,
@@ -661,327 +707,397 @@ module Bitcoin
       free_tx_bytes: 1_000,
       dust: CENT,
       per_dust_fee: false,
-      bip34_height: 227931,
+      bip34_height: 227_931,
       dns_seeds: [
-        "seed.bitcoin.sipa.be",
-        "dnsseed.bluematt.me",
-        "dnsseed.bitcoin.dashjr.org",
-        "bitseed.xf2.org",
-        "dnsseed.webbtc.com",
+        'seed.bitcoin.sipa.be',
+        'dnsseed.bluematt.me',
+        'dnsseed.bitcoin.dashjr.org',
+        'bitseed.xf2.org',
+        'dnsseed.webbtc.com'
       ],
-      genesis_hash: "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+      genesis_hash: '000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f',
       proof_of_work_limit: 0x1d00ffff,
-      alert_pubkeys: ["04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284"],
+      alert_pubkeys: [
+        '04fc9702847840aaf195de8442ebecedf5b095cdbb9bc716bda9110971b28a49e0' \
+        'ead8564ff0db22209e0374782c093bb899692d524e9d6a6956e7c5ecbcd68284'
+      ],
       known_nodes: [
         'relay.eligius.st',
         'mining.bitcoin.cz',
         'blockchain.info',
         'blockexplorer.com',
-        'webbtc.com',
+        'webbtc.com'
       ],
       checkpoints: {
-         11111 => "0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d",
-         33333 => "000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6",
-         74000 => "0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20",
-        105000 => "00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97",
-        134444 => "00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe",
-        168000 => "000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763",
-        193000 => "000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317",
-        210000 => "000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e",
-        216116 => "00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e",
-        225430 => "00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932",
-        290000 => "0000000000000000fa0b2badd05db0178623ebf8dd081fe7eb874c26e27d0b3b",
-        300000 => "000000000000000082ccf8f1557c5d40b21edabb18d2d691cfbf87118bac7254",
-        305000 => "0000000000000000142bb90561e1a907d500bf534a6727a63a92af5b6abc6160",
+        11_111 => '0000000069e244f73d78e8fd29ba2fd2ed618bd6fa2ee92559f542fdb26e7c1d',
+        33_333 => '000000002dd5588a74784eaa7ab0507a18ad16a236e7b1ce69f00d7ddfb5d0a6',
+        74_000 => '0000000000573993a3c9e41ce34471c079dcf5f52a0e824a81e7f953b8661a20',
+        105_000 => '00000000000291ce28027faea320c8d2b054b2e0fe44a773f3eefb151d6bdc97',
+        134_444 => '00000000000005b12ffd4cd315cd34ffd4a594f430ac814c91184a0d42d2b0fe',
+        168_000 => '000000000000099e61ea72015e79632f216fe6cb33d7899acb35b75c8303b763',
+        193_000 => '000000000000059f452a5f7340de6682a977387c17010ff6e6c3bd83ca8b1317',
+        210_000 => '000000000000048b95347e83192f69cf0366076336c639f9b7228e9ba171342e',
+        216_116 => '00000000000001b4f4b433e81ee46494af945cf96014816a4e2370f11b23df4e',
+        225_430 => '00000000000001c108384350f74090433e7fcf79a606b8e797f065b130575932',
+        290_000 => '0000000000000000fa0b2badd05db0178623ebf8dd081fe7eb874c26e27d0b3b',
+        300_000 => '000000000000000082ccf8f1557c5d40b21edabb18d2d691cfbf87118bac7254',
+        305_000 => '0000000000000000142bb90561e1a907d500bf534a6727a63a92af5b6abc6160'
       }
     }
   }
 
-  NETWORKS[:testnet] = NETWORKS[:bitcoin].merge({
-      magic_head: "\xFA\xBF\xB5\xDA",
-      address_version: "6f",
-      p2sh_version: "c4",
-      privkey_version: "ef",
-      extended_privkey_version: "04358394",
-      extended_pubkey_version: "043587cf",
-      bech32_hrp: "tb",
-      default_port: 18333,
-      bip34_height: 21111,
-      dns_seeds: [ ],
-      genesis_hash: "00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008",
-      proof_of_work_limit: 0x1d07fff8,
-      alert_pubkeys: ["04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a"],
-      known_nodes: [],
-      checkpoints: {},
-    })
+  NETWORKS[:testnet] = NETWORKS[:bitcoin].merge(
+    magic_head: "\xFA\xBF\xB5\xDA",
+    address_version: '6f',
+    p2sh_version: 'c4',
+    privkey_version: 'ef',
+    extended_privkey_version: '04358394',
+    extended_pubkey_version: '043587cf',
+    bech32_hrp: 'tb',
+    default_port: 18_333,
+    bip34_height: 21_111,
+    dns_seeds: [],
+    genesis_hash: '00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008',
+    proof_of_work_limit: 0x1d07fff8,
+    alert_pubkeys: [
+      '04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c1' \
+      '4b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a'
+    ],
+    known_nodes: [],
+    checkpoints: {}
+  )
 
-  NETWORKS[:regtest] = NETWORKS[:testnet].merge({
-      bech32_hrp: "bcrt",
-      default_port: 18444,
-      genesis_hash: "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
-      proof_of_work_limit: 0x207fffff,
-      bip34_height: 0,
-    })
+  NETWORKS[:regtest] = NETWORKS[:testnet].merge(
+    bech32_hrp: 'bcrt',
+    default_port: 18_444,
+    genesis_hash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+    proof_of_work_limit: 0x207fffff,
+    bip34_height: 0
+  )
 
-  NETWORKS[:testnet3] = NETWORKS[:testnet].merge({
-      magic_head: "\x0B\x11\x09\x07",
-      no_difficulty: true, # no good. add right testnet3 difficulty calculation instead
-      genesis_hash: "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943",
-      proof_of_work_limit: 0x1d00ffff,
-      dns_seeds: [
-        "testnet-seed.alexykot.me",
-        "testnet-seed.bitcoin.schildbach.de",
-        "testnet-seed.bitcoin.petertodd.org",
-        "testnet-seed.bluematt.me",
-        "dnsseed.test.webbtc.com",
-      ],
-      known_nodes: ["test.webbtc.com"],
-      checkpoints: {
-        # 542 contains invalid transaction
-        542 => "0000000083c1f82cf72c6724f7a317325806384b06408bce7a4327f418dfd5ad",
-        71018 => "000000000010dd93dc55541116b2744eb8f4c3b706df6e8512d231a03fb9e435",
-        200000 => "0000000000287bffd321963ef05feab753ebe274e1d78b2fd4e2bfe9ad3aa6f2",
-        250000 => "0000000005910c146e4e8d71e8aa6617393738a9794b43cf113076dbaf08460b",
-      }
-    })
+  NETWORKS[:testnet3] = NETWORKS[:testnet].merge(
+    magic_head: "\x0B\x11\x09\x07",
+    no_difficulty: true, # no good. add right testnet3 difficulty calculation instead
+    genesis_hash: '000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943',
+    proof_of_work_limit: 0x1d00ffff,
+    dns_seeds: [
+      'testnet-seed.alexykot.me',
+      'testnet-seed.bitcoin.schildbach.de',
+      'testnet-seed.bitcoin.petertodd.org',
+      'testnet-seed.bluematt.me',
+      'dnsseed.test.webbtc.com'
+    ],
+    known_nodes: ['test.webbtc.com'],
+    checkpoints: {
+      # 542 contains invalid transaction
+      542 => '0000000083c1f82cf72c6724f7a317325806384b06408bce7a4327f418dfd5ad',
+      71_018 => '000000000010dd93dc55541116b2744eb8f4c3b706df6e8512d231a03fb9e435',
+      200_000 => '0000000000287bffd321963ef05feab753ebe274e1d78b2fd4e2bfe9ad3aa6f2',
+      250_000 => '0000000005910c146e4e8d71e8aa6617393738a9794b43cf113076dbaf08460b'
+    }
+  )
 
-  NETWORKS[:litecoin] = NETWORKS[:bitcoin].merge({
-      project: :litecoin,
-      magic_head: "\xfb\xc0\xb6\xdb",
-      message_magic: "Litecoin Signed Message:\n",
-      address_version: "30",
-      p2sh_version: "32",
-      legacy_p2sh_versions: ["05"],
-      privkey_version: "b0",
-      bech32_hrp: "ltc",
-      extended_privkey_version: "019d9cfe",
-      extended_pubkey_version: "019da462",
-      default_port: 9333,
-      protocol_version: 70002,
-      max_money: 84_000_000 * COIN,
-      min_tx_fee: 100_000, # 0.001 LTC
-      min_relay_tx_fee: 100_000, # 0.001 LTC
-      free_tx_bytes: 5_000,
-      dust: CENT / 10,
-      per_dust_fee: false,
-      reward_halving: 840_000,
-      retarget_time: 302400, # 3.5 days
-      dns_seeds: [
-        "dnsseed.litecointools.com",
-        "dnsseed.litecoinpool.org",
-        "seed-a.litecoin.loshan.co.uk",
-        "dnsseed.thrasher.io",
-        "dnsseed.koin-project.com",
-      ],
-      genesis_hash: "12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2",
-      proof_of_work_limit: 0x1e0fffff,
-      alert_pubkeys: ["040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9"],
-      known_nodes: [],
-      checkpoints: {
-             1 => "80ca095ed10b02e53d769eb6eaf92cd04e9e0759e5be4a8477b42911ba49c78f",
-             2 => "13957807cdd1d02f993909fa59510e318763f99a506c4c426e3b254af09f40d7",
-          1500 => "841a2965955dd288cfa707a755d05a54e45f8bd476835ec9af4402a2b59a2967",
-          4032 => "9ce90e427198fc0ef05e5905ce3503725b80e26afd35a987965fd7e3d9cf0846",
-          8064 => "eb984353fc5190f210651f150c40b8a4bab9eeeff0b729fcb3987da694430d70",
-         16128 => "602edf1859b7f9a6af809f1d9b0e6cb66fdc1d4d9dcd7a4bec03e12a1ccd153d",
-         23420 => "d80fdf9ca81afd0bd2b2a90ac3a9fe547da58f2530ec874e978fce0b5101b507",
-         50000 => "69dc37eb029b68f075a5012dcc0419c127672adb4f3a32882b2b3e71d07a20a6",
-         80000 => "4fcb7c02f676a300503f49c764a89955a8f920b46a8cbecb4867182ecdb2e90a",
-        120000 => "bd9d26924f05f6daa7f0155f32828ec89e8e29cee9e7121b026a7a3552ac6131",
-        161500 => "dbe89880474f4bb4f75c227c77ba1cdc024991123b28b8418dbbf7798471ff43",
-        179620 => "2ad9c65c990ac00426d18e446e0fd7be2ffa69e9a7dcb28358a50b2b78b9f709",
-        240000 => "7140d1c4b4c2157ca217ee7636f24c9c73db39c4590c4e6eab2e3ea1555088aa",
-        383640 => "2b6809f094a9215bafc65eb3f110a35127a34be94b7d0590a096c3f126c6f364",
-        409004 => "487518d663d9f1fa08611d9395ad74d982b667fbdc0e77e9cf39b4f1355908a3",
-        456000 => "bf34f71cc6366cd487930d06be22f897e34ca6a40501ac7d401be32456372004",
-        541794 => "1cbccbe6920e7c258bbce1f26211084efb19764aa3224bec3f4320d77d6a2fd2",
-      },
-      auxpow_chain_id: 1,
-    })
+  NETWORKS[:litecoin] = NETWORKS[:bitcoin].merge(
+    project: :litecoin,
+    magic_head: "\xfb\xc0\xb6\xdb",
+    message_magic: "Litecoin Signed Message:\n",
+    address_version: '30',
+    p2sh_version: '32',
+    legacy_p2sh_versions: ['05'],
+    privkey_version: 'b0',
+    bech32_hrp: 'ltc',
+    extended_privkey_version: '019d9cfe',
+    extended_pubkey_version: '019da462',
+    default_port: 9333,
+    protocol_version: 70_002,
+    max_money: 84_000_000 * COIN,
+    min_tx_fee: 100_000, # 0.001 LTC
+    min_relay_tx_fee: 100_000, # 0.001 LTC
+    free_tx_bytes: 5_000,
+    dust: CENT / 10,
+    per_dust_fee: false,
+    reward_halving: 840_000,
+    retarget_time: 302_400, # 3.5 days
+    dns_seeds: [
+      'dnsseed.litecointools.com',
+      'dnsseed.litecoinpool.org',
+      'seed-a.litecoin.loshan.co.uk',
+      'dnsseed.thrasher.io',
+      'dnsseed.koin-project.com'
+    ],
+    genesis_hash: '12a765e31ffd4059bada1e25190f6e98c99d9714d334efa41a195a7e7e04bfe2',
+    proof_of_work_limit: 0x1e0fffff,
+    alert_pubkeys: [
+      '040184710fa689ad5023690c80f3a49c8f13f8d45b8c857fbcbc8bc4a8e4d3eb4b10' \
+      'f4d4604fa08dce601aaf0f470216fe1b51850b4acf21b179c45070ac7b03a9'
+    ],
+    known_nodes: [],
+    checkpoints: {
+      1 => '80ca095ed10b02e53d769eb6eaf92cd04e9e0759e5be4a8477b42911ba49c78f',
+      2 => '13957807cdd1d02f993909fa59510e318763f99a506c4c426e3b254af09f40d7',
+      1500 => '841a2965955dd288cfa707a755d05a54e45f8bd476835ec9af4402a2b59a2967',
+      4032 => '9ce90e427198fc0ef05e5905ce3503725b80e26afd35a987965fd7e3d9cf0846',
+      8064 => 'eb984353fc5190f210651f150c40b8a4bab9eeeff0b729fcb3987da694430d70',
+      16_128 => '602edf1859b7f9a6af809f1d9b0e6cb66fdc1d4d9dcd7a4bec03e12a1ccd153d',
+      23_420 => 'd80fdf9ca81afd0bd2b2a90ac3a9fe547da58f2530ec874e978fce0b5101b507',
+      50_000 => '69dc37eb029b68f075a5012dcc0419c127672adb4f3a32882b2b3e71d07a20a6',
+      80_000 => '4fcb7c02f676a300503f49c764a89955a8f920b46a8cbecb4867182ecdb2e90a',
+      120_000 => 'bd9d26924f05f6daa7f0155f32828ec89e8e29cee9e7121b026a7a3552ac6131',
+      161_500 => 'dbe89880474f4bb4f75c227c77ba1cdc024991123b28b8418dbbf7798471ff43',
+      179_620 => '2ad9c65c990ac00426d18e446e0fd7be2ffa69e9a7dcb28358a50b2b78b9f709',
+      240_000 => '7140d1c4b4c2157ca217ee7636f24c9c73db39c4590c4e6eab2e3ea1555088aa',
+      383_640 => '2b6809f094a9215bafc65eb3f110a35127a34be94b7d0590a096c3f126c6f364',
+      409_004 => '487518d663d9f1fa08611d9395ad74d982b667fbdc0e77e9cf39b4f1355908a3',
+      456_000 => 'bf34f71cc6366cd487930d06be22f897e34ca6a40501ac7d401be32456372004',
+      541_794 => '1cbccbe6920e7c258bbce1f26211084efb19764aa3224bec3f4320d77d6a2fd2'
+    },
+    auxpow_chain_id: 1
+  )
 
-  NETWORKS[:litecoin_testnet] = NETWORKS[:litecoin].merge({
-      magic_head: "\xfd\xd2\xc8\xf1",
-      address_version: "6f",
-      p2sh_version: "3a",
-      legacy_p2sh_versions: nil,
-      privkey_version: "ef",
-      bech32_hrp: "tltc",
-      extended_privkey_version: "0436ef7d",
-      extended_pubkey_version: "0436f6e1",
-      default_port: 19335,
-      dns_seeds: [
-        "testnet-seed.ltc.xurious.com",
-        "seed-b.litecoin.loshan.co.uk",
-        "dnsseed-testnet.thrasher.io",
-      ],
-      genesis_hash: "4966625a4b2851d9fdee139e56211a0d88575f59ed816ff5e6a63deb4e3e29a0",
-      alert_pubkeys: ["04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c14b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a"],
-      known_nodes: [],
-      checkpoints: {
-        546 => "bf434a4c665307f52a041ee40faa7bf56284c5f3b5d11bf6182aba537961f86c",
-      }
-    })
+  NETWORKS[:litecoin_testnet] = NETWORKS[:litecoin].merge(
+    magic_head: "\xfd\xd2\xc8\xf1",
+    address_version: '6f',
+    p2sh_version: '3a',
+    legacy_p2sh_versions: nil,
+    privkey_version: 'ef',
+    bech32_hrp: 'tltc',
+    extended_privkey_version: '0436ef7d',
+    extended_pubkey_version: '0436f6e1',
+    default_port: 19_335,
+    dns_seeds: [
+      'testnet-seed.ltc.xurious.com',
+      'seed-b.litecoin.loshan.co.uk',
+      'dnsseed-testnet.thrasher.io'
+    ],
+    genesis_hash: '4966625a4b2851d9fdee139e56211a0d88575f59ed816ff5e6a63deb4e3e29a0',
+    alert_pubkeys: [
+      '04302390343f91cc401d56d68b123028bf52e5fca1939df127f63c6467cdf9c8e2c1' \
+      '4b61104cf817d0b780da337893ecc4aaff1309e536162dabbdb45200ca2b0a'
+    ],
+    known_nodes: [],
+    checkpoints: {
+      546 => 'bf434a4c665307f52a041ee40faa7bf56284c5f3b5d11bf6182aba537961f86c'
+    }
+  )
 
-  NETWORKS[:dogecoin] = NETWORKS[:litecoin].merge({
-      project: :dogecoin,
-      magic_head: "\xc0\xc0\xc0\xc0",
-      message_magic: "Dogecoin Signed Message:\n",
-      address_version: "1e",
-      p2sh_version: "16",
-      privkey_version: "9e",
-      bech32_hrp: nil,
-      extended_privkey_version: "02fac398",
-      extended_pubkey_version: "02facafd",
-      default_port: 22556,
-      protocol_version: 70003,
-      max_money: 100_000_000_000 * COIN,
-      min_tx_fee: COIN,
-      min_relay_tx_fee: COIN,
-      free_tx_bytes: 26_000,
-      dust: COIN,
-      per_dust_fee: true,
-      coinbase_maturity: 30,
-      coinbase_maturity_new: 240,
-      reward_base: 500_000 * COIN,
-      reward_halving: 100_000,
-      retarget_interval: 240,
-      retarget_time: 14400, # 4 hours
-      retarget_time_new: 60, # 1 minute
-      target_spacing: 60, # block interval
-      dns_seeds: [
-        "seed.dogechain.info",
-        "seed.dogecoin.com",
-      ],
-      genesis_hash: "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691",
-      proof_of_work_limit: 0x1e0fffff,
-      alert_pubkeys: [],
-      known_nodes: [
-        "daemons.chain.so",
-        "bootstrap.chain.so",
-      ],
-      checkpoints: {
-        0 => "1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691",
-        42279 => "8444c3ef39a46222e87584ef956ad2c9ef401578bd8b51e8e4b9a86ec3134d3a",
-        42400 => "557bb7c17ed9e6d4a6f9361cfddf7c1fc0bdc394af7019167442b41f507252b4",
-        104679 => "35eb87ae90d44b98898fec8c39577b76cb1eb08e1261cfc10706c8ce9a1d01cf",
-        128370 => "3f9265c94cab7dc3bd6a2ad2fb26c8845cb41cff437e0a75ae006997b4974be6",
-        145000 => "cc47cae70d7c5c92828d3214a266331dde59087d4a39071fa76ddfff9b7bde72",
-        165393 => "7154efb4009e18c1c6a6a79fc6015f48502bcd0a1edd9c20e44cd7cbbe2eeef1",
-        186774 => "3c712c49b34a5f34d4b963750d6ba02b73e8a938d2ee415dcda141d89f5cb23a",
-        199992 => "3408ff829b7104eebaf61fd2ba2203ef2a43af38b95b353e992ef48f00ebb190",
-        225000 => "be148d9c5eab4a33392a6367198796784479720d06bfdd07bd547fe934eea15a",
-        250000 => "0e4bcfe8d970979f7e30e2809ab51908d435677998cf759169407824d4f36460",
-        270639 => "c587a36dd4f60725b9dd01d99694799bef111fc584d659f6756ab06d2a90d911",
-        299742 => "1cc89c0c8a58046bf0222fe131c099852bd9af25a80e07922918ef5fb39d6742",
-        323141 => "60c9f919f9b271add6ef5671e9538bad296d79f7fdc6487ba702bf2ba131d31d",
-        339202 => "8c29048df5ae9df38a67ea9470fdd404d281a3a5c6f33080cd5bf14aa496ab03"
-      },
-      auxpow_chain_id: 0x0062,
-      # Doge-specific hard-fork cutoffs
-      difficulty_change_block: 145000,
-      maturity_change_block: 145000,
-      auxpow_start_block: 371337
-    })
+  NETWORKS[:dogecoin] = NETWORKS[:litecoin].merge(
+    project: :dogecoin,
+    magic_head: "\xc0\xc0\xc0\xc0",
+    message_magic: "Dogecoin Signed Message:\n",
+    address_version: '1e',
+    p2sh_version: '16',
+    privkey_version: '9e',
+    bech32_hrp: nil,
+    extended_privkey_version: '02fac398',
+    extended_pubkey_version: '02facafd',
+    default_port: 22_556,
+    protocol_version: 70_003,
+    max_money: 100_000_000_000 * COIN,
+    min_tx_fee: COIN,
+    min_relay_tx_fee: COIN,
+    free_tx_bytes: 26_000,
+    dust: COIN,
+    per_dust_fee: true,
+    coinbase_maturity: 30,
+    coinbase_maturity_new: 240,
+    reward_base: 500_000 * COIN,
+    reward_halving: 100_000,
+    retarget_interval: 240,
+    retarget_time: 14_400, # 4 hours
+    retarget_time_new: 60, # 1 minute
+    target_spacing: 60, # block interval
+    dns_seeds: [
+      'seed.dogechain.info',
+      'seed.dogecoin.com'
+    ],
+    genesis_hash: '1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691',
+    proof_of_work_limit: 0x1e0fffff,
+    alert_pubkeys: [],
+    known_nodes: [
+      'daemons.chain.so',
+      'bootstrap.chain.so'
+    ],
+    checkpoints: {
+      0 => '1a91e3dace36e2be3bf030a65679fe821aa1d6ef92e7c9902eb318182c355691',
+      42_279 => '8444c3ef39a46222e87584ef956ad2c9ef401578bd8b51e8e4b9a86ec3134d3a',
+      42_400 => '557bb7c17ed9e6d4a6f9361cfddf7c1fc0bdc394af7019167442b41f507252b4',
+      104_679 => '35eb87ae90d44b98898fec8c39577b76cb1eb08e1261cfc10706c8ce9a1d01cf',
+      128_370 => '3f9265c94cab7dc3bd6a2ad2fb26c8845cb41cff437e0a75ae006997b4974be6',
+      145_000 => 'cc47cae70d7c5c92828d3214a266331dde59087d4a39071fa76ddfff9b7bde72',
+      165_393 => '7154efb4009e18c1c6a6a79fc6015f48502bcd0a1edd9c20e44cd7cbbe2eeef1',
+      186_774 => '3c712c49b34a5f34d4b963750d6ba02b73e8a938d2ee415dcda141d89f5cb23a',
+      199_992 => '3408ff829b7104eebaf61fd2ba2203ef2a43af38b95b353e992ef48f00ebb190',
+      225_000 => 'be148d9c5eab4a33392a6367198796784479720d06bfdd07bd547fe934eea15a',
+      250_000 => '0e4bcfe8d970979f7e30e2809ab51908d435677998cf759169407824d4f36460',
+      270_639 => 'c587a36dd4f60725b9dd01d99694799bef111fc584d659f6756ab06d2a90d911',
+      299_742 => '1cc89c0c8a58046bf0222fe131c099852bd9af25a80e07922918ef5fb39d6742',
+      323_141 => '60c9f919f9b271add6ef5671e9538bad296d79f7fdc6487ba702bf2ba131d31d',
+      339_202 => '8c29048df5ae9df38a67ea9470fdd404d281a3a5c6f33080cd5bf14aa496ab03'
+    },
+    auxpow_chain_id: 0x0062,
+    # Doge-specific hard-fork cutoffs
+    difficulty_change_block: 145_000,
+    maturity_change_block: 145_000,
+    auxpow_start_block: 371_337
+  )
 
-  NETWORKS[:dogecoin_testnet] = NETWORKS[:dogecoin].merge({
-      project: :dogecoin,
-      magic_head: "\xfc\xc1\xb7\xdc",
-      address_version: "71",
-      p2sh_version: "c4",
-      privkey_version: "f1",
-      extended_privkey_version: "0432a243",
-      extended_pubkey_version: "0432a9a8",
-      default_port: 44556,
-      protocol_version: 70003,
-      min_tx_fee: COIN,
-      min_relay_tx_fee: COIN,
-      dust: COIN,
-      per_dust_fee: true,
-      free_tx_bytes: 26_000,
-      coinbase_maturity: 30,
-      coinbase_maturity_new: 240,
-      reward_base: 500_000 * COIN,
-      reward_halving: 100_000,
-      retarget_interval: 240,
-      retarget_time: 14400, # 4 hours
-      retarget_time_new: 60, # 1 minute
-      target_spacing: 60, # block interval
-      max_money: 100_000_000_000 * COIN,
-      dns_seeds: [
-        "testdoge-seed.lionservers.de",
-      ],
-      genesis_hash: "bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e",
-      proof_of_work_limit: 0x1e0fffff,
-      alert_pubkeys: [],
-      known_nodes: [
-        "localhost",
-        "testnets.chain.so",
-      ],
-      checkpoints: {
-        546 => "ac537cfeda975e45040e9938d08e40a16e0fbd6388d02d9b4928b8ae0108c626",
-      },
-      auxpow_chain_id: 0x0062,
-      # Doge-specific hard-fork cutoffs
-      difficulty_change_block: 145000,
-      maturity_change_block: 145000,
-      reset_target_block: 157500,
-      auxpow_start_block: 158100
-    })
+  NETWORKS[:dogecoin_testnet] = NETWORKS[:dogecoin].merge(
+    project: :dogecoin,
+    magic_head: "\xfc\xc1\xb7\xdc",
+    address_version: '71',
+    p2sh_version: 'c4',
+    privkey_version: 'f1',
+    extended_privkey_version: '0432a243',
+    extended_pubkey_version: '0432a9a8',
+    default_port: 44_556,
+    protocol_version: 70_003,
+    min_tx_fee: COIN,
+    min_relay_tx_fee: COIN,
+    dust: COIN,
+    per_dust_fee: true,
+    free_tx_bytes: 26_000,
+    coinbase_maturity: 30,
+    coinbase_maturity_new: 240,
+    reward_base: 500_000 * COIN,
+    reward_halving: 100_000,
+    retarget_interval: 240,
+    retarget_time: 14_400, # 4 hours
+    retarget_time_new: 60, # 1 minute
+    target_spacing: 60, # block interval
+    max_money: 100_000_000_000 * COIN,
+    dns_seeds: [
+      'testdoge-seed.lionservers.de'
+    ],
+    genesis_hash: 'bb0a78264637406b6360aad926284d544d7049f45189db5664f3c4d07350559e',
+    proof_of_work_limit: 0x1e0fffff,
+    alert_pubkeys: [],
+    known_nodes: [
+      'localhost',
+      'testnets.chain.so'
+    ],
+    checkpoints: {
+      546 => 'ac537cfeda975e45040e9938d08e40a16e0fbd6388d02d9b4928b8ae0108c626'
+    },
+    auxpow_chain_id: 0x0062,
+    # Doge-specific hard-fork cutoffs
+    difficulty_change_block: 145_000,
+    maturity_change_block: 145_000,
+    reset_target_block: 157_500,
+    auxpow_start_block: 158_100
+  )
 
-  NETWORKS[:namecoin] = NETWORKS[:bitcoin].merge({
-      project: :namecoin,
-      magic_head: "\xF9\xBE\xB4\xFE",
-      address_version: "34",
-      bech32_hrp: nil,
-      default_port: 8334,
-      protocol_version: 35000,
-      min_tx_fee: 50_000,
-      per_dust_fee: true,
-      dns_seeds: [
-        "nmc.seed.quisquis.de",
-        "dnsseed.namecoin.webbtc.com",
-      ],
-      genesis_hash: "000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770",
-      known_nodes: [
-        "bitcoin.tunl.in",
-        "namecoin.webbtc.com",
-        "178.32.31.41",
-        "78.47.86.43",
-        "69.164.206.88",
-      ],
-      checkpoints: {
-        0 => "000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770",
-        19200 => "d8a7c3e01e1e95bcee015e6fcc7583a2ca60b79e5a3aa0a171eddd344ada903d",
-        24000 => "425ab0983cf04f43f346a4ca53049d0dc2db952c0a68eb0b55c3bb64108d5371",
-        97778 => "7553b1e43da01cfcda4335de1caf623e941d43894bd81c2af27b6582f9d83c6f",
-        165000 => "823d7a54ebab04d14c4ba3508f6b5f25977406f4d389539eac0174d52c6b4b62",
-      },
-      auxpow_chain_id: 1
-    })
+  NETWORKS[:namecoin] = NETWORKS[:bitcoin].merge(
+    project: :namecoin,
+    magic_head: "\xF9\xBE\xB4\xFE",
+    address_version: '34',
+    bech32_hrp: nil,
+    default_port: 8334,
+    protocol_version: 35_000,
+    min_tx_fee: 50_000,
+    per_dust_fee: true,
+    dns_seeds: [
+      'nmc.seed.quisquis.de',
+      'dnsseed.namecoin.webbtc.com'
+    ],
+    genesis_hash: '000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770',
+    known_nodes: [
+      'bitcoin.tunl.in',
+      'namecoin.webbtc.com',
+      '178.32.31.41',
+      '78.47.86.43',
+      '69.164.206.88'
+    ],
+    checkpoints: {
+      0 => '000000000062b72c5e2ceb45fbc8587e807c155b0da735e6483dfba2f0a9c770',
+      19_200 => 'd8a7c3e01e1e95bcee015e6fcc7583a2ca60b79e5a3aa0a171eddd344ada903d',
+      24_000 => '425ab0983cf04f43f346a4ca53049d0dc2db952c0a68eb0b55c3bb64108d5371',
+      97_778 => '7553b1e43da01cfcda4335de1caf623e941d43894bd81c2af27b6582f9d83c6f',
+      165_000 => '823d7a54ebab04d14c4ba3508f6b5f25977406f4d389539eac0174d52c6b4b62'
+    },
+    auxpow_chain_id: 1
+  )
 
-  NETWORKS[:namecoin_testnet] = NETWORKS[:namecoin].merge({
-      magic_head: "\xFA\xBF\xB5\xFE",
-      default_port: 18334,
-      genesis_hash: "00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008",
-      dns_seeds: [
-        "dnsseed.test.namecoin.webbtc.com",
-      ],
-      known_nodes: [
-        "test.namecoin.webbtc.com",
-        "nmctest.net",
-        "192.99.247.234"],
-      checkpoints: { }
-    })
+  NETWORKS[:namecoin_testnet] = NETWORKS[:namecoin].merge(
+    magic_head: "\xFA\xBF\xB5\xFE",
+    default_port: 18_334,
+    genesis_hash: '00000007199508e34a9ff81e6ec0c477a4cccff2a4767a8eee39c11db367b008',
+    dns_seeds: [
+      'dnsseed.test.namecoin.webbtc.com'
+    ],
+    known_nodes: [
+      'test.namecoin.webbtc.com',
+      'nmctest.net',
+      '192.99.247.234'
+    ],
+    checkpoints: {}
+  )
 
-  NETWORKS[:namecoin_regtest] = NETWORKS[:namecoin_testnet].merge({
-      magic_head: "\xFA\xBF\xB5\xDA",
-      default_port: 18445,
-      genesis_hash: "0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206",
-      dns_seeds: [], known_nodes: [],
-      proof_of_work_limit: 0x207fffff,
-      checkpoints: { },
-      address_versions: { pubkey_hash: "6f", script_hash: "c4" },
-      privkey_version: "ef",
-    })
+  NETWORKS[:namecoin_regtest] = NETWORKS[:namecoin_testnet].merge(
+    magic_head: "\xFA\xBF\xB5\xDA",
+    default_port: 18_445,
+    genesis_hash: '0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206',
+    dns_seeds: [], known_nodes: [],
+    proof_of_work_limit: 0x207fffff,
+    checkpoints: {},
+    address_versions: { pubkey_hash: '6f', script_hash: 'c4' },
+    privkey_version: 'ef'
+  )
+end
 
+# Extend String for Bitcoin Specifics
+class String
+  include Bitcoin::BinaryExtensions
+end
+
+module OpenSSL
+  # extend OpenSSL::BN fclass for Bitcoin specifics
+  class BN
+    def self.from_hex(hex)
+      new(hex, 16)
+    end
+
+    def to_hex
+      to_i.to_s(16)
+    end
+
+    def to_mpi
+      to_s(0).unpack('C*')
+    end
+  end
+
+  module PKey
+    # Extend OpenSSL::PKey::EC class for Bitcoin specifics
+    class EC
+      def private_key_hex
+        private_key.to_hex.rjust(64, '0')
+      end
+
+      def public_key_hex
+        public_key.to_hex.rjust(130, '0')
+      end
+
+      def pubkey_compressed?
+        public_key.group.point_conversion_form == :compressed
+      end
+
+      # Extend OpenSSL::PKey::EC::Point class for Bitcoin specifics
+      class Point
+        def self.from_hex(group, hex)
+          new(group, BN.from_hex(hex))
+        end
+
+        def to_hex
+          to_bn.to_hex
+        end
+
+        def self.bn2mpi(hex)
+          BN.from_hex(hex).to_mpi
+        end
+
+        def ec_add(point)
+          self.class.new(group, OpenSSL::BN.from_hex(Bitcoin::OpenSSL_EC.ec_add(self, point)))
+        end
+      end
+    end
+  end
 end

--- a/lib/bitcoin/ext_key.rb
+++ b/lib/bitcoin/ext_key.rb
@@ -1,17 +1,15 @@
 # encoding: ascii-8bit
 
-module Bitcoin
+module Bitcoin # rubocop:disable Style/Documentation
+  # Integers modulo the order of the curve(secp256k1)
+  CURVE_ORDER = 115_792_089_237_316_195_423_570_985_008_687_907_852_837_564_279_074_904_382_605_163_141_518_161_494_337 # rubocop:disable Style/LineLength
 
   def self.hmac_sha512(key, data)
     OpenSSL::HMAC.digest(OpenSSL::Digest.new('SHA512'), key, data)
   end
 
-  # Integers modulo the order of the curve(secp256k1)
-  CURVE_ORDER = 115792089237316195423570985008687907852837564279074904382605163141518161494337
-
   # BIP32 Extended private key
   class ExtKey
-
     attr_accessor :depth
     attr_accessor :number
     attr_accessor :chain_code
@@ -25,7 +23,7 @@ module Bitcoin
       key.parent_fingerprint = '00000000'
       l = Bitcoin.hmac_sha512('Bitcoin seed', seed)
       left = OpenSSL::BN.from_hex(l[0..31].bth).to_i
-      raise 'invalid key' if left >= CURVE_ORDER || left == 0
+      raise 'invalid key' if left >= CURVE_ORDER || left.zero?
       key.priv_key = Bitcoin::Key.new(l[0..31].bth)
       key.chain_code = l[32..-1]
       key
@@ -45,7 +43,12 @@ module Bitcoin
 
     # serialize extended private key
     def to_payload
-      Bitcoin.network[:extended_privkey_version].htb << [depth].pack('C') << parent_fingerprint.htb << [number].pack('N') << chain_code << [0x00].pack('C') << priv_key.priv.htb
+      Bitcoin.network[:extended_privkey_version].htb << [depth].pack('C') \
+                                                     << parent_fingerprint.htb \
+                                                     << [number].pack('N') \
+                                                     << chain_code \
+                                                     << [0x00].pack('C') \
+                                                     << priv_key.priv.htb
     end
 
     # Base58 encoded extended private key
@@ -86,11 +89,11 @@ module Bitcoin
       new_key.depth = depth + 1
       new_key.number = number
       new_key.parent_fingerprint = fingerprint
-      if number > (2**31 - 1)
-        data = [0x00].pack('C') << priv_key.priv.htb << [number].pack('N')
-      else
-        data = priv_key.pub.htb << [number].pack('N')
-      end
+      data = if number > (2**31 - 1)
+               [0x00].pack('C') << priv_key.priv.htb << [number].pack('N')
+             else
+               priv_key.pub.htb << [number].pack('N')
+             end
       l = Bitcoin.hmac_sha512(chain_code, data)
       left = OpenSSL::BN.from_hex(l[0..31].bth).to_i
       raise 'invalid key' if left >= CURVE_ORDER
@@ -114,7 +117,6 @@ module Bitcoin
       key.priv_key = Bitcoin::Key.new(data.read(32).bth)
       key
     end
-
   end
 
   # BIP-32 Extended public key
@@ -127,7 +129,11 @@ module Bitcoin
 
     # serialize extended pubkey
     def to_payload
-      Bitcoin.network[:extended_pubkey_version].htb << [depth].pack('C') << parent_fingerprint.htb << [number].pack('N') << chain_code << pub.htb
+      Bitcoin.network[:extended_pubkey_version].htb << [depth].pack('C') \
+                                                    << parent_fingerprint.htb \
+                                                    << [number].pack('N') \
+                                                    << chain_code \
+                                                    << pub.htb
     end
 
     # get public key(hex)
@@ -183,9 +189,10 @@ module Bitcoin
       key.parent_fingerprint = data.read(4).bth
       key.number = data.read(4).unpack('N').first
       key.chain_code = data.read(32)
-      key.pub_key = OpenSSL::PKey::EC::Point.from_hex(Bitcoin.bitcoin_elliptic_curve.group, data.read(33).bth)
+      key.pub_key = OpenSSL::PKey::EC::Point.from_hex(
+        Bitcoin.bitcoin_elliptic_curve.group, data.read(33).bth
+      )
       key
     end
   end
-
 end

--- a/lib/bitcoin/key.rb
+++ b/lib/bitcoin/key.rb
@@ -1,10 +1,8 @@
 # encoding: ascii-8bit
 
 module Bitcoin
-
   # Elliptic Curve key as used in bitcoin.
   class Key
-
     attr_reader :key
 
     MIN_PRIV_KEY_MOD_ORDER = 0x01
@@ -13,8 +11,10 @@ module Bitcoin
 
     # Generate a new keypair.
     #  Bitcoin::Key.generate
-    def self.generate(opts={compressed: true})
-      k = new(nil, nil, opts); k.generate; k
+    def self.generate(opts = { compressed: true })
+      k = new(nil, nil, opts)
+      k.generate
+      k
     end
 
     # Import private key from base58 fromat as described in
@@ -25,25 +25,25 @@ module Bitcoin
       hex = Bitcoin.decode_base58(str)
       compressed = hex.size == 76
       version, key, flag, checksum = hex.unpack("a2a64a#{compressed ? 2 : 0}a8")
-      raise "Invalid version"   unless version == Bitcoin.network[:privkey_version]
-      raise "Invalid checksum"  unless Bitcoin.checksum(version + key + flag) == checksum
-      key = new(key, nil, compressed)
+      raise 'Invalid version'   unless version == Bitcoin.network[:privkey_version]
+      raise 'Invalid checksum'  unless Bitcoin.checksum(version + key + flag) == checksum
+      new(key, nil, compressed)
     end
 
     def ==(other)
-      self.priv == other.priv
+      priv == other.priv
     end
 
     # Create a new key with given +privkey+ and +pubkey+.
     #  Bitcoin::Key.new
     #  Bitcoin::Key.new(privkey)
     #  Bitcoin::Key.new(nil, pubkey)
-    def initialize(privkey = nil, pubkey = nil, opts={compressed: true})
+    def initialize(privkey = nil, pubkey = nil, opts = { compressed: true })
       compressed = opts.is_a?(Hash) ? opts.fetch(:compressed, true) : opts
       @key = Bitcoin.bitcoin_elliptic_curve
       @pubkey_compressed = pubkey ? self.class.is_compressed_pubkey?(pubkey) : compressed
-      set_priv(privkey)  if privkey
-      set_pub(pubkey, @pubkey_compressed)  if pubkey
+      assign_priv(privkey) if privkey
+      set_pub(pubkey, @pubkey_compressed) if pubkey
     end
 
     # Generate new priv/pub key.
@@ -53,13 +53,13 @@ module Bitcoin
 
     # Get the private key (in hex).
     def priv
-      return nil  unless @key.private_key
+      return nil unless @key.private_key
       @key.private_key.to_hex.rjust(64, '0')
     end
 
     # Set the private key to +priv+ (in hex).
-    def priv= priv
-      set_priv(priv)
+    def priv=(priv)
+      assign_priv(priv)
       regenerate_pubkey
     end
 
@@ -89,7 +89,7 @@ module Bitcoin
     end
 
     # Set the public key (in hex).
-    def pub= pub
+    def pub=(pub)
       set_pub(pub)
     end
 
@@ -123,7 +123,6 @@ module Bitcoin
       end
     end
 
-
     def sign_message(message)
       Bitcoin.sign_message(priv, pub, message)['signature']
     end
@@ -150,16 +149,19 @@ module Bitcoin
     # expecting! Otherwise you are merely checking that *someone* validly
     # signed the data.
     def self.recover_compact_signature_to_key(data, signature_base64)
-      signature = signature_base64.unpack("m0")[0]
+      signature = signature_base64.unpack('m0')[0]
       return nil if signature.size != 65
 
       version = signature.unpack('C')[0]
-      return nil if version < 27 or version > 34
- 
-      compressed = (version >= 31) ? (version -= 4; true) : false
+      return nil if version < 27 || version > 34
+
+      compressed = version >= 31
+      version -= 4 if compressed
 
       hash = Bitcoin.bitcoin_signed_message_hash(data)
-      pub_hex = Bitcoin::OpenSSL_EC.recover_public_key_from_signature(hash, signature, version-27, compressed)
+      pub_hex = Bitcoin::OpenSSL_EC.recover_public_key_from_signature(
+        hash, signature, version - 27, compressed
+      )
       return nil unless pub_hex
 
       Key.new(nil, pub_hex)
@@ -169,35 +171,38 @@ module Bitcoin
     # See also Key.from_base58
     def to_base58
       data = Bitcoin.network[:privkey_version] + priv
-      data += "01"  if @pubkey_compressed
-      hex  = data + Bitcoin.checksum(data)
-      Bitcoin.int_to_base58( hex.to_i(16) )
+      data += '01'  if @pubkey_compressed
+      hex = data + Bitcoin.checksum(data)
+      Bitcoin.int_to_base58(hex.to_i(16))
     end
-
 
     # Export private key to bip38 (non-ec-multiply) format as described in
     # https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki
     # See also Key.from_bip38
     def to_bip38(passphrase)
       flagbyte = compressed ? "\xe0" : "\xc0"
-      addresshash = Digest::SHA256.digest( Digest::SHA256.digest( self.addr ) )[0...4]
+      addresshash = Digest::SHA256.digest(Digest::SHA256.digest(addr))[0...4]
 
       require 'scrypt' unless defined?(::SCrypt::Engine)
-      buf = SCrypt::Engine.__sc_crypt(passphrase, addresshash, 16384, 8, 8, 64)
-      derivedhalf1, derivedhalf2 = buf[0...32], buf[32..-1]
+      buf = SCrypt::Engine.__sc_crypt(passphrase, addresshash, 16_384, 8, 8, 64)
+      derivedhalf1 = buf[0...32]
+      derivedhalf2 = buf[32..-1]
 
-      aes = proc{|k,a,b|
-        cipher = OpenSSL::Cipher::AES.new(256, :ECB); cipher.encrypt; cipher.padding = 0; cipher.key = k
-        cipher.update [ (a.to_i(16) ^ b.unpack("H*")[0].to_i(16)).to_s(16).rjust(32, '0') ].pack("H*")
+      aes = proc { |k, a, b|
+        cipher = OpenSSL::Cipher::AES.new(256, :ECB)
+        cipher.encrypt
+        cipher.padding = 0
+        cipher.key = k
+        cipher.update [(a.to_i(16) ^ b.unpack('H*')[0].to_i(16)).to_s(16).rjust(32, '0')].pack('H*')
       }
 
-      encryptedhalf1 = aes.call(derivedhalf2, self.priv[0...32], derivedhalf1[0...16])
-      encryptedhalf2 = aes.call(derivedhalf2, self.priv[32..-1], derivedhalf1[16..-1])
+      encryptedhalf1 = aes.call(derivedhalf2, priv[0...32], derivedhalf1[0...16])
+      encryptedhalf2 = aes.call(derivedhalf2, priv[32..-1], derivedhalf1[16..-1])
 
       encrypted_privkey = "\x01\x42" + flagbyte + addresshash + encryptedhalf1 + encryptedhalf2
-      encrypted_privkey += Digest::SHA256.digest( Digest::SHA256.digest( encrypted_privkey ) )[0...4]
+      encrypted_privkey += Digest::SHA256.digest(Digest::SHA256.digest(encrypted_privkey))[0...4]
 
-      encrypted_privkey = Bitcoin.encode_base58( encrypted_privkey.unpack("H*")[0] )
+      Bitcoin.encode_base58(encrypted_privkey.unpack('H*')[0])
     end
 
     # Import private key from bip38 (non-ec-multiply) fromat as described in
@@ -205,18 +210,24 @@ module Bitcoin
     # See also #to_bip38
     def self.from_bip38(encrypted_privkey, passphrase)
       version, flagbyte, addresshash, encryptedhalf1, encryptedhalf2, checksum =
-        [ Bitcoin.decode_base58(encrypted_privkey) ].pack("H*").unpack("a2aa4a16a16a4")
-      compressed = (flagbyte == "\xe0") ? true : false
+        [Bitcoin.decode_base58(encrypted_privkey)].pack('H*').unpack('a2aa4a16a16a4')
+      compressed = flagbyte == "\xe0" ? true : false
 
-      raise "Invalid version"   unless version == "\x01\x42"
-      raise "Invalid checksum"  unless Digest::SHA256.digest(Digest::SHA256.digest(version + flagbyte + addresshash + encryptedhalf1 + encryptedhalf2))[0...4] == checksum
+      raise 'Invalid version' unless version == "\x01\x42"
+      raise 'Invalid checksum' unless Digest::SHA256.digest(
+        Digest::SHA256.digest(version + flagbyte + addresshash + encryptedhalf1 + encryptedhalf2)
+      )[0...4] == checksum
 
       require 'scrypt' unless defined?(::SCrypt::Engine)
-      buf = SCrypt::Engine.__sc_crypt(passphrase, addresshash, 16384, 8, 8, 64)
-      derivedhalf1, derivedhalf2 = buf[0...32], buf[32..-1]
+      buf = SCrypt::Engine.__sc_crypt(passphrase, addresshash, 16_384, 8, 8, 64)
+      derivedhalf1 = buf[0...32]
+      derivedhalf2 = buf[32..-1]
 
-      aes = proc{|k,a|
-        cipher = OpenSSL::Cipher::AES.new(256, :ECB); cipher.decrypt; cipher.padding = 0; cipher.key = k
+      aes = proc { |k, a|
+        cipher = OpenSSL::Cipher::AES.new(256, :ECB)
+        cipher.decrypt
+        cipher.padding = 0
+        cipher.key = k
         cipher.update(a)
       }
 
@@ -224,11 +235,13 @@ module Bitcoin
       decryptedhalf1 = aes.call(derivedhalf2, encryptedhalf1)
 
       priv = decryptedhalf1 + decryptedhalf2
-      priv = (priv.unpack("H*")[0].to_i(16) ^ derivedhalf1.unpack("H*")[0].to_i(16)).to_s(16).rjust(64, '0')
+      priv = (
+        priv.unpack('H*')[0].to_i(16) ^ derivedhalf1.unpack('H*')[0].to_i(16)
+      ).to_s(16).rjust(64, '0')
       key = Bitcoin::Key.new(priv, nil, compressed)
 
-      if Digest::SHA256.digest( Digest::SHA256.digest( key.addr ) )[0...4] != addresshash
-        raise "Invalid addresshash! Password is likely incorrect."
+      if Digest::SHA256.digest(Digest::SHA256.digest(key.addr))[0...4] != addresshash
+        raise 'Invalid addresshash! Password is likely incorrect.'
       end
 
       key
@@ -237,17 +250,28 @@ module Bitcoin
     # Import private key from warp fromat as described in
     # https://github.com/keybase/warpwallet
     # https://keybase.io/warp/
-    def self.from_warp(passphrase, salt="", compressed=false)
+    def self.from_warp(passphrase, salt = '', compressed = false)
       require 'scrypt' unless defined?(::SCrypt::Engine)
-      s1 = SCrypt::Engine.scrypt(passphrase+"\x01", salt+"\x01", 2**18, 8, 1, 32)
-      s2 = OpenSSL::PKCS5.pbkdf2_hmac(passphrase+"\x02", salt+"\x02", 2**16, 32, OpenSSL::Digest::SHA256.new)
-      s3 = s1.bytes.zip(s2.bytes).map{|a,b| a ^ b }.pack("C*")
+      s1 = SCrypt::Engine.scrypt(passphrase + "\x01", salt + "\x01", 2**18, 8, 1, 32)
+      s2 = OpenSSL::PKCS5.pbkdf2_hmac(
+        passphrase + "\x02", salt + "\x02", 2**16, 32, OpenSSL::Digest::SHA256.new
+      )
+      s3 = s1.bytes.zip(s2.bytes).map { |a, b| a ^ b }.pack('C*')
 
-      key = Bitcoin::Key.new(s3.unpack("H*")[0], nil, compressed)
+      key = Bitcoin::Key.new(s3.unpack('H*')[0], nil, compressed)
       # [key.addr, key.to_base58, [s1,s2,s3].map{|i| i.unpack("H*")[0] }, compressed]
       key
     end
 
+    def self.compressed_pubkey?(pub)
+      %w[02 03].include?(pub[0..1])
+    end
+
+    def self.is_compressed_pubkey?(pub) # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Key.is_compressed_pubkey?` is deprecated. ' \
+           'Use `Key.compressed_pubkey?` instead.'
+      compressed_pubkey?(pub)
+    end
 
     protected
 
@@ -258,23 +282,22 @@ module Bitcoin
     end
 
     # Set +priv+ as the new private key (converting from hex).
-    def set_priv(priv)
+    def assign_priv(priv)
       value = priv.to_i(16)
-      raise 'private key is not on curve' unless MIN_PRIV_KEY_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
+      in_range = MIN_PRIV_KEY_MOD_ORDER <= value && value <= MAX_PRIV_KEY_MOD_ORDER
+      raise 'private key is not on curve' unless in_range
       @key.private_key = OpenSSL::BN.from_hex(priv)
+    end
+
+    def set_priv(priv) # rubocop:disable Naming/AccessorMethodName
+      warn '[DEPRECATION] `Key.set_priv` is deprecated. Use `Key.assign_priv` instead.'
+      assign_priv(priv)
     end
 
     # Set +pub+ as the new public key (converting from hex).
     def set_pub(pub, compressed = nil)
-      @pubkey_compressed = compressed == nil ? self.class.is_compressed_pubkey?(pub) : compressed
+      @pubkey_compressed = compressed.nil? ? self.class.is_compressed_pubkey?(pub) : compressed
       @key.public_key = OpenSSL::PKey::EC::Point.from_hex(@key.group, pub)
     end
-
-    def self.is_compressed_pubkey?(pub)
-      ["02","03"].include?(pub[0..1])
-    end
-
   end
-
 end
-

--- a/lib/bitcoin/litecoin.rb
+++ b/lib/bitcoin/litecoin.rb
@@ -1,43 +1,45 @@
 require 'openssl'
 
 module Litecoin
+  # https://litecoin.info/index.php/Scrypt
   module Scrypt
-
-    def scrypt_1024_1_1_256_sp(input, scratchpad=[])
+    def self.scrypt_1024_1_1_256_sp(input, scratchpad = [])
       b = pbkdf2_sha256(input, input, 1, 128)
-      x = b.unpack("V*")
+      x = b.unpack('V*')
       v = scratchpad
 
-      1024.times{|i|
-        v[(i*32)...((i*32)+32)] = x.dup
+      1024.times do |i|
+        v[(i * 32)...((i * 32) + 32)] = x.dup
         xor_salsa8(x, x, 0, 16)
         xor_salsa8(x, x, 16, 0)
-      }
+      end
 
-      1024.times{|i|
+      1024.times do
         j = 32 * (x[16] & 1023)
-        32.times{|k| x[k] ^= v[j+k] }
+        32.times { |k| x[k] ^= v[j + k] }
         xor_salsa8(x, x, 0, 16)
         xor_salsa8(x, x, 16, 0)
-      }
+      end
 
-      pbkdf2_sha256(input, x.pack("V*"), 1, 32)
+      pbkdf2_sha256(input, x.pack('V*'), 1, 32)
     end
 
-    def pbkdf2_sha256(pass, salt, c=1, dk_len=128)
-      raise "pbkdf2_sha256: wrong length." if pass.bytesize != 80 or ![80,128].include?(salt.bytesize)
-      raise "pbkdf2_sha256: wrong dk length." if ![128,32].include?(dk_len)
-      OpenSSL::PKCS5.pbkdf2_hmac(pass, salt, iter=c, dk_len, OpenSSL::Digest::SHA256.new)
+    def self.pbkdf2_sha256(pass, salt, c = 1, dk_len = 128)
+      raise 'pbkdf2_sha256: wrong length.' if pass.bytesize != 80 || \
+                                              ![80, 128].include?(salt.bytesize)
+      raise 'pbkdf2_sha256: wrong dk length.' unless [128, 32].include?(dk_len)
+      OpenSSL::PKCS5.pbkdf2_hmac(pass, salt, c, dk_len, OpenSSL::Digest::SHA256.new)
     end
 
-    def rotl(a, b)
-      a &= 0xffffffff; ((a << b) | (a >> (32 - b))) & 0xffffffff
+    def self.rotl(a, b)
+      a &= 0xffffffff
+      ((a << b) | (a >> (32 - b))) & 0xffffffff
     end
 
-    def xor_salsa8(a, b, a_offset, b_offset)
-      x = 16.times.map{|n| a[a_offset+n] ^= b[b_offset+n] }
+    def self.xor_salsa8(a, b, a_offset, b_offset)
+      x = Array.new(16) { |n| a[a_offset + n] ^= b[b_offset + n] }
 
-      4.times{
+      4.times do
         [
           [4, 0, 12, 7], [9, 5, 1, 7],  [14, 10, 6, 7], [3, 15, 11, 7],
           [8, 4, 0, 9], [13, 9, 5, 9],  [2, 14, 10, 9], [7, 3, 15, 9],
@@ -48,36 +50,42 @@ module Litecoin
           [2, 1, 0, 9], [7, 6, 5, 9],  [8, 11, 10, 9], [13, 12, 15, 9],
           [3, 2, 1, 13], [4, 7, 6, 13],  [9, 8, 11, 13], [14, 13, 12, 13],
           [0, 3, 2, 18], [5, 4, 7, 18],  [10, 9, 8, 18], [15, 14, 13, 18]
-        ].each{|i|
-          x[ i[0] ] ^= rotl(x[ i[1] ] + x[ i[2] ], i[3])
-        }
-      }
+        ].each do |i|
+          x[i[0]] ^= rotl(x[i[1]] + x[i[2]], i[3])
+        end
+      end
 
-      16.times{|n| a[a_offset+n] = (a[a_offset+n] + x[n]) & 0xffffffff }
+      16.times { |n| a[a_offset + n] = (a[a_offset + n] + x[n]) & 0xffffffff }
       true
     end
-
-    extend self
   end
 end
 
+if $PROGRAM_NAME == __FILE__
+  secret_hex = '020000004c1271c211717198227392b029a64a7971931d351b387bb80db027f270411e398a07046f' \
+               '7d4a08dd815412a8712f874a7ebf0507e3878bd24e20a3b73fd750a667d2f451eac7471b00de6659'
+  secret_bytes = [secret_hex].pack('H*')
 
-if $0 == __FILE__
-  secret_hex = "020000004c1271c211717198227392b029a64a7971931d351b387bb80db027f270411e398a07046f7d4a08dd815412a8712f874a7ebf0507e3878bd24e20a3b73fd750a667d2f451eac7471b00de6659"
-  secret_bytes = [secret_hex].pack("H*")
- 
   begin
-    require "scrypt"
+    require 'scrypt'
     hash = SCrypt::Engine.__sc_crypt(secret_bytes, secret_bytes, 1024, 1, 1, 32)
-    p hash.reverse.unpack("H*")[0] == "00000000002bef4107f882f6115e0b01f348d21195dacd3582aa2dabd7985806"
+    expected_hex = '00000000002bef4107f882f6115e0b01f348d21195dacd3582aa2dabd7985806'
+    p hash.reverse.unpack('H*')[0] == expected_hex
   rescue LoadError
-    puts "scrypt gem not found, using native scrypt"
-    p Litecoin::Scrypt.scrypt_1024_1_1_256_sp(secret_bytes).reverse.unpack("H*")[0] == "00000000002bef4107f882f6115e0b01f348d21195dacd3582aa2dabd7985806"
+    puts 'scrypt gem not found, using native scrypt'
+    expected_hex = '00000000002bef4107f882f6115e0b01f348d21195dacd3582aa2dabd7985806'
+    p Litecoin::Scrypt.scrypt_1024_1_1_256_sp(secret_bytes).reverse.unpack('H*')[0] == expected_hex
   end
 
   require 'benchmark'
-  Benchmark.bmbm{|x|
-    x.report("v1"){ SCrypt::Engine.__sc_crypt(secret_bytes, secret_bytes, 1024, 1, 1, 32).reverse.unpack("H*") rescue nil }
-    x.report("v2"){ Litecoin::Scrypt.scrypt_1024_1_1_256_sp(secret_bytes).reverse.unpack("H*")[0] }
-  }
+  Benchmark.bmbm do |x|
+    x.report('v1') do
+      begin
+        SCrypt::Engine.__sc_crypt(secret_bytes, secret_bytes, 1024, 1, 1, 32).reverse.unpack('H*')
+      rescue
+        nil
+      end
+    end
+    x.report('v2') { Litecoin::Scrypt.scrypt_1024_1_1_256_sp(secret_bytes).reverse.unpack('H*')[0] }
+  end
 end

--- a/lib/bitcoin/protocol.rb
+++ b/lib/bitcoin/protocol.rb
@@ -5,13 +5,12 @@ require 'digest/sha2'
 require 'json'
 
 module Bitcoin
+  # bitcoin/src/main.h
   module Protocol
-
-    # bitcoin/src/main.h
-    MAX_INV_SZ = 50000
+    MAX_INV_SZ = 50_000
 
     # BIP 0031, pong message, is enabled for all versions AFTER this one
-    BIP0031_VERSION = 60000
+    BIP0031_VERSION = 60_000
 
     autoload :ScriptWitness, 'bitcoin/protocol/script_witness'
     autoload :TxIn,          'bitcoin/protocol/txin'
@@ -23,46 +22,52 @@ module Bitcoin
     autoload :Reject,        'bitcoin/protocol/reject'
     autoload :Version,       'bitcoin/protocol/version'
     autoload :AuxPow,        'bitcoin/protocol/aux_pow'
-    autoload :PartialMerkleTree,  'bitcoin/protocol/partial_merkle_tree'
+    autoload :PartialMerkleTree, 'bitcoin/protocol/partial_merkle_tree'
 
     autoload :Handler, 'bitcoin/protocol/handler'
     autoload :Parser,  'bitcoin/protocol/parser'
 
     Uniq = rand(0xffffffffffffffff)
 
-    # var_int refers to https://en.bitcoin.it/wiki/Protocol_specification#Variable_length_integer and is what Satoshi called "CompactSize"
-    # BitcoinQT has later added even more compact format called CVarInt to use in its local block storage. CVarInt is not implemented here.
+    # var_int refers to https://en.bitcoin.it/wiki/Protocol_specification#Variable_length_integer
+    # and is what Satoshi called "CompactSize" BitcoinQT has later added even more compact format
+    # called CVarInt to use in its local block storage. CVarInt is not implemented here.
     def self.unpack_var_int(payload)
-      case payload.unpack("C")[0] # TODO add test cases
-      when 0xfd; payload.unpack("xva*")
-      when 0xfe; payload.unpack("xVa*")
-      when 0xff; payload.unpack("xQa*") # TODO add little-endian version of Q
-      else;      payload.unpack("Ca*")
+      case payload.unpack('C')[0] # TODO: add test cases
+      when 0xfd then payload.unpack('xva*')
+      when 0xfe then payload.unpack('xVa*')
+      when 0xff then payload.unpack('xQa*') # TODO: add little-endian version of Q
+      else; payload.unpack('Ca*')
       end
     end
 
     def self.unpack_var_int_from_io(io)
-      uchar = io.read(1).unpack("C")[0]
+      uchar = io.read(1).unpack('C')[0]
       case uchar
-      when 0xfd; io.read(2).unpack("v")[0]
-      when 0xfe; io.read(4).unpack("V")[0]
-      when 0xff; io.read(8).unpack("Q")[0]
-      else;      uchar
+      when 0xfd then io.read(2).unpack('v')[0]
+      when 0xfe then io.read(4).unpack('V')[0]
+      when 0xff then io.read(8).unpack('Q')[0]
+      else; uchar
       end
     end
 
     def self.pack_var_int(i)
-      if    i <  0xfd;                [      i].pack("C")
-      elsif i <= 0xffff;              [0xfd, i].pack("Cv")
-      elsif i <= 0xffffffff;          [0xfe, i].pack("CV")
-      elsif i <= 0xffffffffffffffff;  [0xff, i].pack("CQ")
-      else raise "int(#{i}) too large!"
+      if i <  0xfd
+        [i].pack('C')
+      elsif i <= 0xffff
+        [0xfd, i].pack('Cv')
+      elsif i <= 0xffffffff
+        [0xfe, i].pack('CV')
+      elsif i <= 0xffffffffffffffff
+        [0xff, i].pack('CQ')
+      else
+        raise "int(#{i}) too large!"
       end
     end
 
     def self.unpack_var_string(payload)
       size, payload = unpack_var_int(payload)
-      size > 0 ? (_, payload = payload.unpack("a#{size}a*")) : [nil, payload]
+      size > 0 ? payload.unpack("a#{size}a*") : [nil, payload]
     end
 
     def self.unpack_var_string_from_io(buf)
@@ -77,115 +82,117 @@ module Bitcoin
     def self.unpack_var_string_array(payload) # unpacks set<string>
       buf = StringIO.new(payload)
       size = unpack_var_int_from_io(buf)
-      return [nil, buf.read] if size == 0
+      return [nil, buf.read] if size.zero?
       strings = []
-      size.times{
+      size.times do
         break if buf.eof?
         strings << unpack_var_string_from_io(buf)
-      }
+      end
       [strings, buf.read]
     end
 
     def self.unpack_var_int_array(payload) # unpacks set<int>
       buf = StringIO.new(payload)
-      size =  unpack_var_int_from_io(buf)
-      return [nil, buf.read] if size == 0
+      size = unpack_var_int_from_io(buf)
+      return [nil, buf.read] if size.zero?
       ints = []
-      size.times{
+      size.times do
         break if buf.eof?
         ints << unpack_var_int_from_io(buf)
-      }
+      end
       [ints, buf.read]
     end
 
     def self.unpack_boolean(payload)
-      bdata, payload = payload.unpack("Ca*")
-      [ (bdata == 0 ? false : true), payload ]
+      bdata, payload = payload.unpack('Ca*')
+      [(bdata.zero? ? false : true), payload]
     end
 
     def self.pack_boolean(b)
-      (b == true) ? [0xFF].pack("C") : [0x00].pack("C")
+      b == true ? [0xFF].pack('C') : [0x00].pack('C')
     end
 
     BINARY = Encoding.find('ASCII-8BIT')
 
     def self.pkt(command, payload)
       cmd      = command.ljust(12, "\x00")[0...12]
-      length   = [payload.bytesize].pack("V")
+      length   = [payload.bytesize].pack('V')
       checksum = Digest::SHA256.digest(Digest::SHA256.digest(payload))[0...4]
-      pkt      = "".force_encoding(BINARY)
-      pkt << Bitcoin.network[:magic_head].force_encoding(BINARY)
-      pkt << cmd.force_encoding(BINARY)
-      pkt << length
-      pkt << checksum
-      pkt << payload.dup.force_encoding(BINARY)
+      pkt      = ''.force_encoding(BINARY)
+      pkt << Bitcoin.network[:magic_head].force_encoding(BINARY) \
+          << cmd.force_encoding(BINARY) \
+          << length \
+          << checksum \
+          << payload.dup.force_encoding(BINARY)
     end
 
-    def self.version_pkt(from_id, from=nil, to=nil, last_block=nil, time=nil, user_agent=nil, version=nil)
+    def self.version_pkt( # rubocop:disable Metrics/ParameterLists
+      from_id, from = nil, to = nil, last_block = nil, time = nil, user_agent = nil, version = nil
+    )
       opts = if from_id.is_a?(Hash)
-        from_id
-      else
-        STDERR.puts "Bitcoin::Protocol.version_pkt - API deprecated. please change it soon.."
-        {
-          :nonce => from_id, :from => from, :to => to, :last_block => last_block,
-          :time => time, :user_agent => user_agent, :version => version
-        }
-      end
+               from_id
+             else
+               STDERR.puts 'Bitcoin::Protocol.version_pkt - API deprecated. please change it soon..'
+               {
+                 nonce: from_id, from: from, to: to, last_block: last_block,
+                 time: time, user_agent: user_agent, version: version
+               }
+             end
       version = Protocol::Version.new(opts)
       version.to_pkt
     end
 
     def self.ping_pkt(nonce = rand(0xffffffff))
-      pkt("ping", [nonce].pack("Q"))
+      pkt('ping', [nonce].pack('Q'))
     end
 
     def self.pong_pkt(nonce)
-      pkt("pong", [nonce].pack("Q"))
+      pkt('pong', [nonce].pack('Q'))
     end
 
     def self.verack_pkt
-      pkt("verack", "")
+      pkt('verack', '')
     end
 
     TypeLookup = Hash[:tx, 1, :block, 2, :filtered_block, 3, nil, 0]
 
     def self.getdata_pkt(type, hashes)
       return if hashes.size > MAX_INV_SZ
-      t = [ TypeLookup[type] ].pack("V")
-      pkt("getdata", pack_var_int(hashes.size) + hashes.map{|hash| t + hash[0..32].reverse }.join)
+      t = [TypeLookup[type]].pack('V')
+      pkt('getdata', pack_var_int(hashes.size) + hashes.map { |hash| t + hash[0..32].reverse }.join)
     end
 
     def self.inv_pkt(type, hashes)
       return if hashes.size > MAX_INV_SZ
-      t = [ TypeLookup[type] ].pack("V")
-      pkt("inv", pack_var_int(hashes.size) + hashes.map{|hash| t + hash[0..32].reverse }.join)
+      t = [TypeLookup[type]].pack('V')
+      pkt('inv', pack_var_int(hashes.size) + hashes.map { |hash| t + hash[0..32].reverse }.join)
     end
 
-    DEFAULT_STOP_HASH = "00"*32
+    DEFAULT_STOP_HASH = '00' * 32
 
     def self.locator_payload(version, locator_hashes, stop_hash)
       [
-        [version].pack("V"),
+        [version].pack('V'),
         pack_var_int(locator_hashes.size),
-        locator_hashes.map{|l| l.htb_reverse }.join,
+        locator_hashes.map(&:htb_reverse).join,
         stop_hash.htb_reverse
       ].join
     end
 
-    def self.getblocks_pkt(version, locator_hashes, stop_hash=DEFAULT_STOP_HASH)
-      pkt "getblocks",  locator_payload(version, locator_hashes, stop_hash)
+    def self.getblocks_pkt(version, locator_hashes, stop_hash = DEFAULT_STOP_HASH)
+      pkt 'getblocks',  locator_payload(version, locator_hashes, stop_hash)
     end
 
-    def self.getheaders_pkt(version, locator_hashes, stop_hash=DEFAULT_STOP_HASH)
-      pkt "getheaders", locator_payload(version, locator_hashes, stop_hash)
+    def self.getheaders_pkt(version, locator_hashes, stop_hash = DEFAULT_STOP_HASH)
+      pkt 'getheaders', locator_payload(version, locator_hashes, stop_hash)
     end
 
-    def self.headers_pkt(version, blocks)
-      pkt "headers", [pack_var_int(blocks.size), blocks.map{|block| block.block_header}.join].join
+    def self.headers_pkt(_version, blocks)
+      pkt 'headers', [pack_var_int(blocks.size), blocks.map(&:block_header).join].join
     end
 
     def self.read_binary_file(path)
-      File.open(path, 'rb'){|f| f.read }
+      File.open(path, 'rb', &:read)
     end
   end
 

--- a/lib/bitcoin/script.rb
+++ b/lib/bitcoin/script.rb
@@ -2,1673 +2,1873 @@
 
 require 'bitcoin'
 
-class Bitcoin::Script
+module Bitcoin
+  # https://en.bitcoin.it/wiki/Script
+  class Script
+    OP_0           = 0
+    OP_FALSE       = 0
+    OP_1           = 81
+    OP_TRUE        = 81
+    OP_2           = 0x52
+    OP_3           = 0x53
+    OP_4           = 0x54
+    OP_5           = 0x55
+    OP_6           = 0x56
+    OP_7           = 0x57
+    OP_8           = 0x58
+    OP_9           = 0x59
+    OP_10          = 0x5a
+    OP_11          = 0x5b
+    OP_12          = 0x5c
+    OP_13          = 0x5d
+    OP_14          = 0x5e
+    OP_15          = 0x5f
+    OP_16          = 0x60
 
-  OP_0           = 0
-  OP_FALSE       = 0
-  OP_1           = 81
-  OP_TRUE        = 81
-  OP_2           = 0x52
-  OP_3           = 0x53
-  OP_4           = 0x54
-  OP_5           = 0x55
-  OP_6           = 0x56
-  OP_7           = 0x57
-  OP_8           = 0x58
-  OP_9           = 0x59
-  OP_10          = 0x5a
-  OP_11          = 0x5b
-  OP_12          = 0x5c
-  OP_13          = 0x5d
-  OP_14          = 0x5e
-  OP_15          = 0x5f
-  OP_16          = 0x60
+    OP_PUSHDATA0 = 0
+    OP_PUSHDATA1 = 76
+    OP_PUSHDATA2 = 77
+    OP_PUSHDATA4 = 78
+    OP_PUSHDATA_INVALID = 238 # 0xEE
+    OP_NOP = 97
+    OP_DUP = 118
+    OP_HASH160 = 169
+    OP_EQUAL = 135
+    OP_VERIFY = 105
+    OP_EQUALVERIFY = 136
+    OP_CHECKSIG = 172
+    OP_CHECKSIGVERIFY = 173
+    OP_CHECKMULTISIG = 174
+    OP_CHECKMULTISIGVERIFY = 175
+    OP_TOALTSTACK = 107
+    OP_FROMALTSTACK = 108
+    OP_TUCK = 125
+    OP_SWAP = 124
+    OP_BOOLAND = 154
+    OP_ADD = 147
+    OP_SUB = 148
+    OP_GREATERTHANOREQUAL = 162
+    OP_DROP = 117
+    OP_HASH256 = 170
+    OP_SHA256 = 168
+    OP_SHA1 = 167
+    OP_RIPEMD160 = 166
+    OP_NOP1 = 176
+    OP_NOP2 = 177
+    OP_NOP3 = 178
+    OP_NOP4 = 179
+    OP_NOP5 = 180
+    OP_NOP6 = 181
+    OP_NOP7 = 182
+    OP_NOP8 = 183
+    OP_NOP9 = 184
+    OP_NOP10 = 185
+    OP_CODESEPARATOR = 171
+    OP_MIN = 163
+    OP_MAX = 164
+    OP_2OVER = 112
+    OP_2ROT = 113
+    OP_2SWAP = 114
+    OP_IFDUP = 115
+    OP_DEPTH = 116
+    OP_1NEGATE = 79
+    OP_WITHIN = 165
+    OP_NUMEQUAL = 156
+    OP_NUMEQUALVERIFY = 157
+    OP_LESSTHAN = 159
+    OP_LESSTHANOREQUAL = 161
+    OP_GREATERTHAN = 160
+    OP_NOT = 145
+    OP_0NOTEQUAL = 146
+    OP_ABS = 144
+    OP_1ADD = 139
+    OP_1SUB = 140
+    OP_NEGATE = 143
+    OP_BOOLOR = 155
+    OP_NUMNOTEQUAL = 158
+    OP_RETURN = 106
+    OP_OVER = 120
+    OP_IF = 99
+    OP_NOTIF = 100
+    OP_ELSE = 103
+    OP_ENDIF = 104
+    OP_PICK = 121
+    OP_SIZE = 130
+    OP_VER = 98
+    OP_ROLL = 122
+    OP_ROT = 123
+    OP_2DROP = 109
+    OP_2DUP = 110
+    OP_3DUP = 111
+    OP_NIP = 119
 
-  OP_PUSHDATA0   = 0
-  OP_PUSHDATA1   = 76
-  OP_PUSHDATA2   = 77
-  OP_PUSHDATA4   = 78
-  OP_PUSHDATA_INVALID = 238 # 0xEE
-  OP_NOP         = 97
-  OP_DUP         = 118
-  OP_HASH160     = 169
-  OP_EQUAL       = 135
-  OP_VERIFY      = 105
-  OP_EQUALVERIFY = 136
-  OP_CHECKSIG    = 172
-  OP_CHECKSIGVERIFY      = 173
-  OP_CHECKMULTISIG       = 174
-  OP_CHECKMULTISIGVERIFY = 175
-  OP_TOALTSTACK   = 107
-  OP_FROMALTSTACK = 108
-  OP_TUCK         = 125
-  OP_SWAP         = 124
-  OP_BOOLAND      = 154
-  OP_ADD          = 147
-  OP_SUB          = 148
-  OP_GREATERTHANOREQUAL = 162
-  OP_DROP         = 117
-  OP_HASH256      = 170
-  OP_SHA256       = 168
-  OP_SHA1         = 167
-  OP_RIPEMD160    = 166
-  OP_NOP1         = 176
-  OP_NOP2         = 177
-  OP_NOP3         = 178
-  OP_NOP4         = 179
-  OP_NOP5         = 180
-  OP_NOP6         = 181
-  OP_NOP7         = 182
-  OP_NOP8         = 183
-  OP_NOP9         = 184
-  OP_NOP10        = 185
-  OP_CODESEPARATOR = 171
-  OP_MIN          = 163
-  OP_MAX          = 164
-  OP_2OVER        = 112
-  OP_2ROT         = 113
-  OP_2SWAP        = 114
-  OP_IFDUP        = 115
-  OP_DEPTH        = 116
-  OP_1NEGATE      = 79
-  OP_WITHIN         = 165
-  OP_NUMEQUAL       = 156
-  OP_NUMEQUALVERIFY = 157
-  OP_LESSTHAN     = 159
-  OP_LESSTHANOREQUAL = 161
-  OP_GREATERTHAN  = 160
-  OP_NOT            = 145
-  OP_0NOTEQUAL = 146
-  OP_ABS = 144
-  OP_1ADD = 139
-  OP_1SUB = 140
-  OP_NEGATE = 143
-  OP_BOOLOR = 155
-  OP_NUMNOTEQUAL = 158
-  OP_RETURN = 106
-  OP_OVER = 120
-  OP_IF = 99
-  OP_NOTIF = 100
-  OP_ELSE = 103
-  OP_ENDIF = 104
-  OP_PICK = 121
-  OP_SIZE = 130
-  OP_VER = 98
-  OP_ROLL = 122
-  OP_ROT = 123
-  OP_2DROP = 109
-  OP_2DUP = 110
-  OP_3DUP = 111
-  OP_NIP = 119
+    OP_CAT = 126
+    OP_SUBSTR = 127
+    OP_LEFT = 128
+    OP_RIGHT = 129
+    OP_INVERT = 131
+    OP_AND = 132
+    OP_OR = 133
+    OP_XOR = 134
+    OP_2MUL = 141
+    OP_2DIV = 142
+    OP_MUL = 149
+    OP_DIV = 150
+    OP_MOD = 151
+    OP_LSHIFT = 152
+    OP_RSHIFT = 153
 
-  OP_CAT = 126
-  OP_SUBSTR = 127
-  OP_LEFT = 128
-  OP_RIGHT = 129
-  OP_INVERT = 131
-  OP_AND = 132
-  OP_OR = 133
-  OP_XOR = 134
-  OP_2MUL = 141
-  OP_2DIV = 142
-  OP_MUL = 149
-  OP_DIV = 150
-  OP_MOD = 151
-  OP_LSHIFT = 152
-  OP_RSHIFT = 153
+    OP_INVALIDOPCODE = 0xff
 
-  OP_INVALIDOPCODE = 0xff
+    OPCODES = Hash[*constants.grep(/^OP_/).map { |i| [const_get(i), i.to_s] }.flatten]
+    OPCODES[0] = '0'
+    OPCODES[81] = '1'
 
-  OPCODES = Hash[*constants.grep(/^OP_/).map{|i| [const_get(i), i.to_s] }.flatten]
-  OPCODES[0] = "0"
-  OPCODES[81] = "1"
+    OPCODES_ALIAS = {
+      'OP_TRUE'  => OP_1,
+      'OP_FALSE' => OP_0,
+      'OP_EVAL' => OP_NOP1,
+      'OP_CHECKHASHVERIFY' => OP_NOP2
+    }.freeze
 
-  OPCODES_ALIAS = {
-    "OP_TRUE"  => OP_1,
-    "OP_FALSE" => OP_0,
-    "OP_EVAL" => OP_NOP1,
-    "OP_CHECKHASHVERIFY" => OP_NOP2,
-  }
+    DISABLED_OPCODES = [
+      OP_CAT, OP_SUBSTR, OP_LEFT, OP_RIGHT, OP_INVERT,
+      OP_AND, OP_OR, OP_XOR, OP_2MUL, OP_2DIV, OP_MUL,
+      OP_DIV, OP_MOD, OP_LSHIFT, OP_RSHIFT
+    ].freeze
 
-  DISABLED_OPCODES = [
-    OP_CAT, OP_SUBSTR, OP_LEFT, OP_RIGHT, OP_INVERT,
-    OP_AND, OP_OR, OP_XOR, OP_2MUL, OP_2DIV, OP_MUL,
-    OP_DIV, OP_MOD, OP_LSHIFT, OP_RSHIFT
-  ]
+    OP_2_16 = (82..96).to_a
 
-  OP_2_16 = (82..96).to_a
+    OPCODES_PARSE_BINARY = {} # rubocop:disable Style/MutableConstant
+    OPCODES.each { |k, v| OPCODES_PARSE_BINARY[k] = v }
+    OP_2_16.each { |i| OPCODES_PARSE_BINARY[i] = (OP_2_16.index(i) + 2).to_s }
+    OPCODES_PARSE_BINARY.freeze
 
+    OPCODES_PARSE_STRING = {} # rubocop:disable Style/MutableConstant
+    OPCODES.each { |k, v| OPCODES_PARSE_STRING[v] = k }
+    OPCODES_ALIAS.each { |k, v| OPCODES_PARSE_STRING[k] = v }
+    2.upto(16).each { |i| OPCODES_PARSE_STRING["OP_#{i}"] = OP_2_16[i - 2] }
+    2.upto(16).each { |i| OPCODES_PARSE_STRING[i.to_s] = OP_2_16[i - 2] }
+    [1, 2, 4].each { |i| OPCODES_PARSE_STRING.delete("OP_PUSHDATA#{i}") }
+    OPCODES_PARSE_STRING.freeze
 
-  OPCODES_PARSE_BINARY = {}
-  OPCODES.each{|k,v| OPCODES_PARSE_BINARY[k] = v }
-  OP_2_16.each{|i|   OPCODES_PARSE_BINARY[i] = (OP_2_16.index(i)+2).to_s }
+    SIGHASH_TYPE = {
+      all: 1,
+      none: 2,
+      single: 3,
+      forkid: 64,
+      anyonecanpay: 128
+    }.freeze
 
-  OPCODES_PARSE_STRING = {}
-  OPCODES.each{|k,v|       OPCODES_PARSE_STRING[v] = k }
-  OPCODES_ALIAS.each{|k,v| OPCODES_PARSE_STRING[k] = v }
-  2.upto(16).each{|i|      OPCODES_PARSE_STRING["OP_#{i}"] = OP_2_16[i-2] }
-  2.upto(16).each{|i|      OPCODES_PARSE_STRING["#{i}"   ] = OP_2_16[i-2] }
-  [1,2,4].each{|i|         OPCODES_PARSE_STRING.delete("OP_PUSHDATA#{i}") }
+    attr_reader :raw, :chunks, :debug, :stack
 
-  SIGHASH_TYPE = {
-    all: 1,
-    none: 2,
-    single: 3,
-    forkid: 64,
-    anyonecanpay: 128
-  }.freeze
+    # create a new script. +bytes+ is typically input_script + output_script
+    def initialize(input_script, previous_output_script = nil)
+      @raw_byte_sizes = [
+        input_script.bytesize,
+        previous_output_script ? previous_output_script.bytesize : 0
+      ]
+      @input_script = input_script
+      @previous_output_script = previous_output_script
+      @parse_invalid = nil
+      @inner_p2sh = nil
+      @script_codeseparator_index = nil
 
-  attr_reader :raw, :chunks, :debug, :stack
-
-  # create a new script. +bytes+ is typically input_script + output_script
-
-  def initialize(input_script, previous_output_script=nil)
-    @raw_byte_sizes = [input_script.bytesize, previous_output_script ? previous_output_script.bytesize : 0]
-    @input_script, @previous_output_script = input_script, previous_output_script
-    @parse_invalid = nil
-    @inner_p2sh = nil
-    @script_codeseparator_index = nil
-
-    @raw = if @previous_output_script
-             @input_script + [ Bitcoin::Script::OP_CODESEPARATOR ].pack("C") + @previous_output_script
-           else
-             @input_script
-           end
-
-    @chunks = parse(@input_script)
-
-    if previous_output_script
-      @script_codeseparator_index = @chunks.size
-      @chunks << Bitcoin::Script::OP_CODESEPARATOR
-      @chunks += parse(@previous_output_script)
-    end
-
-    @stack, @stack_alt, @exec_stack = [], [], []
-    @last_codeseparator_index = 0
-    @do_exec = true
-  end
-
-  class ::String
-    attr_accessor :bitcoin_pushdata
-    attr_accessor :bitcoin_pushdata_length
-  end
-
-  # parse raw script
-  def parse(bytes, offset=0)
-    program = bytes.unpack("C*")
-    chunks = []
-    until program.empty?
-      opcode = program.shift
-
-      if (opcode > 0) && (opcode < OP_PUSHDATA1)
-        len, tmp = opcode, program[0]
-        chunks << program.shift(len).pack("C*")
-
-        # 0x16 = 22 due to OP_2_16 from_string parsing
-        if len == 1 && tmp && tmp <= 22
-          chunks.last.bitcoin_pushdata = OP_PUSHDATA0
-          chunks.last.bitcoin_pushdata_length = len
-        else
-          raise "invalid OP_PUSHDATA0" if len != chunks.last.bytesize
-        end
-      elsif (opcode == OP_PUSHDATA1)
-        len = program.shift(1)[0]
-        chunks << program.shift(len).pack("C*")
-
-        unless len > OP_PUSHDATA1 && len <= 0xff
-          chunks.last.bitcoin_pushdata = OP_PUSHDATA1
-          chunks.last.bitcoin_pushdata_length = len
-        else
-          raise "invalid OP_PUSHDATA1" if len != chunks.last.bytesize
-        end
-      elsif (opcode == OP_PUSHDATA2)
-        len = program.shift(2).pack("C*").unpack("v")[0]
-        chunks << program.shift(len).pack("C*")
-
-        unless len > 0xff && len <= 0xffff
-          chunks.last.bitcoin_pushdata = OP_PUSHDATA2
-          chunks.last.bitcoin_pushdata_length = len
-        else
-          raise "invalid OP_PUSHDATA2" if len != chunks.last.bytesize
-        end
-      elsif (opcode == OP_PUSHDATA4)
-        len = program.shift(4).pack("C*").unpack("V")[0]
-        chunks << program.shift(len).pack("C*")
-
-        unless len > 0xffff # && len <= 0xffffffff
-          chunks.last.bitcoin_pushdata = OP_PUSHDATA4
-          chunks.last.bitcoin_pushdata_length = len
-        else
-          raise "invalid OP_PUSHDATA4" if len != chunks.last.bytesize
-        end
-      else
-        chunks << opcode
-      end
-    end
-    chunks
-  rescue => ex
-    # bail out! #run returns false but serialization roundtrips still create the right payload.
-    chunks.pop if ex.message.include?("invalid OP_PUSHDATA")
-    @parse_invalid = true
-    c = bytes.unpack("C*").pack("C*")
-    c.bitcoin_pushdata = OP_PUSHDATA_INVALID
-    c.bitcoin_pushdata_length = c.bytesize
-    chunks << c
-  end
-
-  # string representation of the script
-  def to_string(chunks=nil)
-    string = ""
-    (chunks || @chunks).each.with_index{|i,idx|
-      string << " " unless idx == 0
-      string << case i
-      when Bitcoin::Integer
-        if opcode = OPCODES_PARSE_BINARY[i]
-          opcode
-        else
-          "(opcode-#{i})"
-        end
-      when String
-        if i.bitcoin_pushdata
-          "#{i.bitcoin_pushdata}:#{i.bitcoin_pushdata_length}:".force_encoding('binary') + i.unpack("H*")[0]
-        else
-          i.unpack("H*")[0]
-        end
-      end
-    }
-    string
-  end
-
-  def to_binary(chunks=nil)
-
-    (chunks || @chunks).map{|chunk|
-      case chunk
-      when Bitcoin::Integer; [chunk].pack("C*")
-      when String; self.class.pack_pushdata(chunk)
-      end
-    }.join
-  end
-  alias :to_payload :to_binary
-
-  def to_binary_without_signatures(drop_signatures, chunks=nil)
-    buf = []
-    (chunks || @chunks).each.with_index{|chunk,idx|
-      if chunk == OP_CODESEPARATOR and idx <= @last_codeseparator_index
-        buf.clear
-      elsif chunk == OP_CODESEPARATOR
-        if idx == @script_codeseparator_index
-          break
-        else
-          # skip
-        end
-      elsif drop_signatures.none?{|e| e == chunk }
-        buf << chunk
-      end
-    }
-    to_binary(buf)
-  end
-
-  # Returns a script that deleted the script before the index specified by separator_index.
-  def subscript_codeseparator(separator_index)
-    buf = []
-    process_separator_index = 0
-    (chunks || @chunks).each{|chunk|
-      buf << chunk if process_separator_index == separator_index
-      process_separator_index += 1 if chunk == OP_CODESEPARATOR and process_separator_index < separator_index
-    }
-    to_binary(buf)
-  end
-
-  # Adds opcode (OP_0, OP_1, ... OP_CHECKSIG etc.)
-  # Returns self.
-  def append_opcode(opcode)
-    raise "Opcode should be an integer" if !opcode.is_a?(Bitcoin::Integer)
-    if opcode >= OP_0 && opcode <= 0xff
-      @chunks << opcode
-    else
-      raise "Opcode should be within [0x00, 0xff]"
-    end
-    self
-  end
-
-  # Adds the opcode corresponding to the given number. Returns self.
-  def append_number(number)
-    opcode =
-      case number
-      when -1 then OP_1NEGATE
-      when 0 then OP_0
-      when 1 then OP_1
-      when 2..16 then OP_2 + (16 - number)
-      end
-    raise "No opcode for number #{number}" if opcode.nil?
-    append_opcode(opcode)
-  end
-
-  # Adds binary string as pushdata. Pushdata will be encoded in the most compact form
-  # (unless the string contains internal info about serialization that's added by Script class)
-  # Returns self.
-  def append_pushdata(pushdata_string)
-    raise "Pushdata should be a string" if !pushdata_string.is_a?(String)
-    @chunks << pushdata_string
-    self
-  end
-
-  def self.pack_pushdata(data)
-    size = data.bytesize
-
-    if data.bitcoin_pushdata
-      size = data.bitcoin_pushdata_length
-      pack_pushdata_align(data.bitcoin_pushdata, size, data)
-    else
-      head = if size < OP_PUSHDATA1
-               [size].pack("C")
-             elsif size <= 0xff
-               [OP_PUSHDATA1, size].pack("CC")
-             elsif size <= 0xffff
-               [OP_PUSHDATA2, size].pack("Cv")
-             #elsif size <= 0xffffffff
+      @raw = if @previous_output_script
+               @input_script +
+                 [Bitcoin::Script::OP_CODESEPARATOR].pack('C') +
+                 @previous_output_script
              else
-               [OP_PUSHDATA4, size].pack("CV")
+               @input_script
              end
-      head + data
-    end
-  end
 
-  def self.pack_pushdata_align(pushdata, len, data)
-    case pushdata
-    when OP_PUSHDATA1
-      [OP_PUSHDATA1, len].pack("CC") + data
-    when OP_PUSHDATA2
-      [OP_PUSHDATA2, len].pack("Cv") + data
-    when OP_PUSHDATA4
-      [OP_PUSHDATA4, len].pack("CV") + data
-    when OP_PUSHDATA_INVALID
-      data
-    else # OP_PUSHDATA0
-      [len].pack("C") + data
-    end
-  end
+      @chunks = parse(@input_script)
 
-  # script object of a string representation
-  def self.from_string(input_script, previous_output_script=nil)
-    if previous_output_script
-      new(binary_from_string(input_script), binary_from_string(previous_output_script))
-    else
-      new(binary_from_string(input_script))
-    end
-  end
-
-  class ScriptOpcodeError < StandardError; end
-
-  # raw script binary of a string representation
-  def self.binary_from_string(script_string)
-    buf = ""
-    script_string.split(" ").each{|i|
-      i = if opcode = OPCODES_PARSE_STRING[i]
-        opcode
-      else
-        case i
-        when /OP_PUSHDATA/             # skip
-        when /OP_(.+)$/;               raise ScriptOpcodeError, "#{i} not defined!"
-        when /\(opcode\-(\d+)\)/;      $1.to_i
-        when "(opcode";                # skip  # fix invalid opcode parsing
-        when /^(\d+)\)/;               $1.to_i # fix invalid opcode parsing
-        when /(\d+):(\d+):(.+)?/
-          pushdata, len, data = $1.to_i, $2.to_i, $3
-          pack_pushdata_align(pushdata, len, [data].pack("H*"))
-        else
-          data = [i].pack("H*")
-          pack_pushdata(data)
-        end
+      if previous_output_script
+        @script_codeseparator_index = @chunks.size
+        @chunks << Bitcoin::Script::OP_CODESEPARATOR
+        @chunks += parse(@previous_output_script)
       end
 
-      buf << if i.is_a?(Bitcoin::Integer)
-               i < 256 ? [i].pack("C") : [OpenSSL::BN.new(i.to_s,10).to_hex].pack("H*")
-             else
-               i
-             end if i
-    }
-    buf
-  end
-
-  def invalid?
-    @script_invalid ||= false
-  end
-
-  # run the script. +check_callback+ is called for OP_CHECKSIG operations
-  def run(block_timestamp=Time.now.to_i, opts={}, &check_callback)
-    return false if @parse_invalid
-
-    #p [to_string, block_timestamp, is_p2sh?]
-    @script_invalid = true if @raw_byte_sizes.any?{|size| size > 10_000 }
-    @last_codeseparator_index = 0
-
-    if block_timestamp >= 1333238400 # Pay to Script Hash (BIP 0016)
-      return pay_to_script_hash(block_timestamp, opts, check_callback)  if is_p2sh?
+      @stack = []
+      @stack_alt = []
+      @exec_stack = []
+      @last_codeseparator_index = 0
+      @do_exec = true
     end
 
-    @debug = []
-    @chunks.each.with_index{|chunk,idx|
-      break if invalid?
-      @chunk_last_index = idx
+    # parse raw script
+    # rubocop:disable Metrics/MethodLength, CyclomaticComplexity, PerceivedComplexity
+    def parse(bytes, _ = 0)
+      program = bytes.unpack('C*')
+      chunks = []
+      until program.empty?
+        opcode = program.shift
 
-      @debug << @stack.map{|i| i.unpack("H*") rescue i}
-      @do_exec = @exec_stack.count(false) == 0 ? true : false
-      #p [@stack, @do_exec]
+        if opcode > 0 && opcode < OP_PUSHDATA1
+          len = opcode
+          tmp = program[0]
+          chunks << program.shift(len).pack('C*')
 
-      case chunk
-      when Bitcoin::Integer
-        if DISABLED_OPCODES.include?(chunk)
-          @script_invalid = true
-          @debug << "DISABLED_#{OPCODES[chunk]}"
-          break
+          # 0x16 = 22 due to OP_2_16 from_string parsing
+          if len == 1 && tmp && tmp <= 22
+            chunks.last.bitcoin_pushdata = OP_PUSHDATA0
+            chunks.last.bitcoin_pushdata_length = len
+          elsif len != chunks.last.bytesize
+            raise 'invalid OP_PUSHDATA0'
+          end
+        elsif opcode == OP_PUSHDATA1
+          len = program.shift(1)[0]
+          chunks << program.shift(len).pack('C*')
+
+          if len <= OP_PUSHDATA1 || len > 0xff
+            chunks.last.bitcoin_pushdata = OP_PUSHDATA1
+            chunks.last.bitcoin_pushdata_length = len
+          elsif len != chunks.last.bytesize
+            raise 'invalid OP_PUSHDATA1'
+          end
+        elsif opcode == OP_PUSHDATA2
+          len = program.shift(2).pack('C*').unpack('v')[0]
+          chunks << program.shift(len).pack('C*')
+
+          if len <= 0xff || len > 0xffff
+            chunks.last.bitcoin_pushdata = OP_PUSHDATA2
+            chunks.last.bitcoin_pushdata_length = len
+          elsif len != chunks.last.bytesize
+            raise 'invalid OP_PUSHDATA2'
+          end
+        elsif opcode == OP_PUSHDATA4
+          len = program.shift(4).pack('C*').unpack('V')[0]
+          chunks << program.shift(len).pack('C*')
+
+          if len <= 0xfff # && len <= 0xffffffff
+            chunks.last.bitcoin_pushdata = OP_PUSHDATA4
+            chunks.last.bitcoin_pushdata_length = len
+          elsif len != chunks.last.bytesize
+            raise 'invalid OP_PUSHDATA4'
+          end
+        else
+          chunks << opcode
         end
+      end
+      chunks
+    rescue => ex
+      # bail out! #run returns false but serialization roundtrips still create the right payload.
+      chunks.pop if ex.message.include?('invalid OP_PUSHDATA')
+      @parse_invalid = true
+      c = bytes.unpack('C*').pack('C*')
+      c.bitcoin_pushdata = OP_PUSHDATA_INVALID
+      c.bitcoin_pushdata_length = c.bytesize
+      chunks << c
+    end
+    # rubocop:enable Metrics/MethodLength, CyclomaticComplexity, PerceivedComplexity
 
-        next @debug.pop  unless (@do_exec || (OP_IF <= chunk && chunk <= OP_ENDIF))
+    # string representation of the script
+    def to_string(chunks = nil)
+      string = ''
+      (chunks || @chunks).each.with_index do |i, idx|
+        string << ' ' unless idx.zero?
+        string << case i
+                  when Bitcoin::Integer
+                    opcode = OPCODES_PARSE_BINARY[i]
+                    opcode ? opcode : "(opcode-#{i})"
+                  when String
+                    if i.bitcoin_pushdata
+                      "#{i.bitcoin_pushdata}:#{i.bitcoin_pushdata_length}:" \
+                  .force_encoding('binary') + i.unpack('H*')[0]
+                    else
+                      i.unpack('H*')[0]
+                    end
+                  end
+      end
+      string
+    end
+
+    def to_binary(chunks = nil)
+      (chunks || @chunks).map do |chunk|
+        case chunk
+        when Bitcoin::Integer
+          [chunk].pack('C*')
+        when String
+          self.class.pack_pushdata(chunk)
+        end
+      end.join
+    end
+    alias to_payload to_binary
+
+    def to_binary_without_signatures(drop_signatures, chunks = nil)
+      buf = []
+      (chunks || @chunks).each.with_index do |chunk, idx|
+        if chunk == OP_CODESEPARATOR && idx <= @last_codeseparator_index
+          buf.clear
+        elsif chunk == OP_CODESEPARATOR
+          break if idx == @script_codeseparator_index
+        elsif drop_signatures.none? { |e| e == chunk }
+          buf << chunk
+        end
+      end
+      to_binary(buf)
+    end
+
+    # Returns a script that deleted the script before the index specified by separator_index.
+    def subscript_codeseparator(separator_index)
+      buf = []
+      process_separator_index = 0
+      (chunks || @chunks).each do |chunk|
+        buf << chunk if process_separator_index == separator_index
+        process_separator_index += 1 if chunk == OP_CODESEPARATOR &&
+                                        process_separator_index < separator_index
+      end
+      to_binary(buf)
+    end
+
+    # Adds opcode (OP_0, OP_1, ... OP_CHECKSIG etc.)
+    # Returns self.
+    def append_opcode(opcode)
+      raise 'Opcode should be an integer' unless opcode.is_a?(Bitcoin::Integer)
+      raise 'Opcode should be within [0x00, 0xff]' unless opcode >= OP_0 && opcode <= 0xff
+      @chunks << opcode
+      self
+    end
+
+    # Adds the opcode corresponding to the given number. Returns self.
+    def append_number(number)
+      opcode =
+        case number
+        when -1 then OP_1NEGATE
+        when 0 then OP_0
+        when 1 then OP_1
+        when 2..16 then OP_2 + (16 - number)
+        end
+      raise "No opcode for number #{number}" if opcode.nil?
+      append_opcode(opcode)
+    end
+
+    # Adds binary string as pushdata. Pushdata will be encoded in the most compact form
+    # (unless the string contains internal info about serialization that's added by Script class)
+    # Returns self.
+    def append_pushdata(pushdata_string)
+      raise 'Pushdata should be a string' unless pushdata_string.is_a?(String)
+      @chunks << pushdata_string
+      self
+    end
+
+    def self.pack_pushdata(data)
+      size = data.bytesize
+
+      if data.bitcoin_pushdata
+        size = data.bitcoin_pushdata_length
+        pack_pushdata_align(data.bitcoin_pushdata, size, data)
+      else
+        head = if size < OP_PUSHDATA1
+                 [size].pack('C')
+               elsif size <= 0xff
+                 [OP_PUSHDATA1, size].pack('CC')
+               elsif size <= 0xffff
+                 [OP_PUSHDATA2, size].pack('Cv')
+               # elsif size <= 0xffffffff
+               else
+                 [OP_PUSHDATA4, size].pack('CV')
+               end
+        head + data
+      end
+    end
+
+    def self.pack_pushdata_align(pushdata, len, data)
+      case pushdata
+      when OP_PUSHDATA1
+        [OP_PUSHDATA1, len].pack('CC') + data
+      when OP_PUSHDATA2
+        [OP_PUSHDATA2, len].pack('Cv') + data
+      when OP_PUSHDATA4
+        [OP_PUSHDATA4, len].pack('CV') + data
+      when OP_PUSHDATA_INVALID
+        data
+      else # OP_PUSHDATA0
+        [len].pack('C') + data
+      end
+    end
+
+    # script object of a string representation
+    def self.from_string(input_script, previous_output_script = nil)
+      if previous_output_script
+        new(binary_from_string(input_script), binary_from_string(previous_output_script))
+      else
+        new(binary_from_string(input_script))
+      end
+    end
+
+    class ScriptOpcodeError < StandardError; end
+
+    # raw script binary of a string representation
+    # rubocop:disable CyclomaticComplexity,EmptyWhen
+    def self.binary_from_string(script_string)
+      buf = ''
+      script_string.split(' ').each do |i|
+        opcode = OPCODES_PARSE_STRING[i]
+        i = if opcode
+              opcode
+            else
+              case i
+              when /OP_PUSHDATA/ # skip
+              when /OP_(.+)$/
+                raise ScriptOpcodeError, "#{i} not defined!"
+              when /\(opcode\-(\d+)\)/
+                Regexp.last_match[1].to_i
+              when '(opcode'; # skip  # fix invalid opcode parsing
+              when /^(\d+)\)/
+                Regexp.last_match[1].to_i # fix invalid opcode parsing
+              when /(\d+):(\d+):(.+)?/
+                pushdata = Regexp.last_match[1].to_i
+                len = Regexp.last_match[2].to_i
+                data = Regexp.last_match[3]
+                pack_pushdata_align(pushdata, len, [data].pack('H*'))
+              else
+                data = [i].pack('H*')
+                pack_pushdata(data)
+              end
+            end
+
+        next unless i
+        buf << if i.is_a?(Bitcoin::Integer)
+                 i < 256 ? [i].pack('C') : [OpenSSL::BN.new(i.to_s, 10).to_hex].pack('H*')
+               else
+                 i
+               end
+      end
+      buf
+    end
+    # rubocop:enable CyclomaticComplexity,EmptyWhen
+
+    def invalid?
+      @script_invalid ||= false
+    end
+
+    # run the script. +check_callback+ is called for OP_CHECKSIG operations
+    # rubocop:disable Metrics/MethodLength, CyclomaticComplexity, PerceivedComplexity
+    def run(block_timestamp = Time.now.to_i, opts = {}, &check_callback)
+      return false if @parse_invalid
+
+      # p [to_string, block_timestamp, is_p2sh?]
+      @script_invalid = true if @raw_byte_sizes.any? { |size| size > 10_000 }
+      @last_codeseparator_index = 0
+
+      if block_timestamp >= 1_333_238_400 # Pay to Script Hash (BIP 0016)
+        return pay_to_script_hash(block_timestamp, opts, check_callback) if is_p2sh?
+      end
+
+      @debug = []
+      @chunks.each.with_index do |chunk, idx|
+        break if invalid?
+        @chunk_last_index = idx
+
+        @debug << @stack.map do |i|
+          begin
+            i.unpack('H*')
+          rescue
+            i
+          end
+        end
+        @do_exec = @exec_stack.count(false).zero?
+        # p [@stack, @do_exec]
 
         case chunk
-        when *OPCODES_METHOD.keys
-          m = method( n=OPCODES_METHOD[chunk] )
-          @debug << n.to_s.upcase
-          # invoke opcode method
-          case m.arity
-          when 0
-            m.call
-          when 1
-            m.call(check_callback)
-          when -2 # One fixed parameter, one optional
-            m.call(check_callback, opts)
-          else
-            puts "Bitcoin::Script: opcode #{name} method parameters invalid"
+        when Bitcoin::Integer
+          if DISABLED_OPCODES.include?(chunk)
+            @script_invalid = true
+            @debug << "DISABLED_#{OPCODES[chunk]}"
+            break
           end
-        when *OP_2_16
-          @stack << OP_2_16.index(chunk) + 2
-          @debug << "OP_#{chunk-80}"
-        else
-          name = OPCODES[chunk] || chunk
-          puts "Bitcoin::Script: opcode #{name} unkown or not implemented\n#{to_string.inspect}"
-          raise "opcode #{name} unkown or not implemented"
-        end
-      when String
-        if @do_exec
-          @debug << "PUSH DATA #{chunk.unpack("H*")[0]}"
-          @stack << chunk
-        else
-          @debug.pop
-        end
-      end
-    }
-    @debug << @stack.map{|i| i.unpack("H*") rescue i } #if @do_exec
 
-    if @script_invalid
-      @stack << 0
-      @debug << "INVALID TRANSACTION"
-    end
+          next @debug.pop unless @do_exec || OP_IF <= chunk && chunk <= OP_ENDIF
 
-    @debug << "RESULT"
-    return false if @stack.empty?
-    return false if cast_to_bool(@stack.pop) == false
-    true
-  end
-
-  def invalid
-    @script_invalid = true; nil
-  end
-
-  def self.drop_signatures(script_pubkey, drop_signatures)
-    script = new(script_pubkey).to_string.split(" ").delete_if{|c| drop_signatures.include?(c) }.join(" ")
-    script_pubkey = binary_from_string(script)
-  end
-
-  # pay_to_script_hash: https://en.bitcoin.it/wiki/BIP_0016
-  #
-  # <sig> {<pub> OP_CHECKSIG} | OP_HASH160 <script_hash> OP_EQUAL
-  def pay_to_script_hash(block_timestamp, opts, check_callback)
-    return false if @chunks.size < 4
-    *rest, script, _, script_hash, _ = @chunks
-    script = rest.pop if script == OP_CODESEPARATOR
-    script, script_hash = cast_to_string(script), cast_to_string(script_hash)
-
-    return false unless Bitcoin.hash160(script.unpack("H*")[0]) == script_hash.unpack("H*")[0]
-    return true  if check_callback == :check
-
-    script = self.class.new(to_binary(rest) + script).inner_p2sh!(script)
-    result = script.run(block_timestamp, opts, &check_callback)
-    @debug = script.debug
-    @stack = script.stack # Set the execution stack to match the redeem script, so checks on stack contents at end of script execution validate correctly
-    result
-  end
-
-  def inner_p2sh!(script=nil); @inner_p2sh = true; @inner_script_code = script; self; end
-  def inner_p2sh?; @inner_p2sh; end
-
-  # get the inner p2sh script
-  def inner_p2sh_script
-    return nil if @chunks.size < 4
-    *rest, script, _, script_hash, _ = @chunks
-    script = rest.pop if script == OP_CODESEPARATOR
-    script, script_hash = cast_to_string(script), cast_to_string(script_hash)
-
-    return nil unless Bitcoin.hash160(script.unpack("H*")[0]) == script_hash.unpack("H*")[0]
-    script
-  end
-
-  # is this a :script_hash (pay-to-script-hash/p2sh) script?
-  def is_pay_to_script_hash?
-    @inner_p2sh ||= false
-    return false if @inner_p2sh
-    if @previous_output_script
-      chunks = Bitcoin::Script.new(@previous_output_script).chunks
-      chunks.size == 3 &&
-      chunks[-3] == OP_HASH160 &&
-      chunks[-2].is_a?(String) && chunks[-2].bytesize == 20 &&
-      chunks[-1] == OP_EQUAL
-    else
-      @chunks.size >= 3 &&
-      @chunks[-3] == OP_HASH160 &&
-      @chunks[-2].is_a?(String) && @chunks[-2].bytesize == 20 &&
-      @chunks[-1] == OP_EQUAL &&
-      # make sure the script_sig matches the p2sh hash from the pk_script (if there is one)
-      (@chunks.size > 3 ? pay_to_script_hash(nil, nil, :check) : true)
-    end
-  end
-  alias :is_p2sh? :is_pay_to_script_hash?
-
-  # check if script is in one of the recognized standard formats
-  def is_standard?
-    is_pubkey? || is_hash160? || is_multisig? || is_p2sh?  || is_op_return? || is_witness_v0_keyhash? || is_witness_v0_scripthash?
-  end
-
-  # is this a pubkey script
-  def is_pubkey?
-    return false if @chunks.size != 2
-    (@chunks[1] == OP_CHECKSIG) && @chunks[0] && (@chunks[0].is_a?(String)) && @chunks[0] != OP_RETURN
-  end
-  alias :is_send_to_ip? :is_pubkey?
-
-  # is this a hash160 (address) script
-  def is_hash160?
-    return false  if @chunks.size != 5
-    (@chunks[0..1] + @chunks[-2..-1]) ==
-      [OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG] &&
-      @chunks[2].is_a?(String) && @chunks[2].bytesize == 20
-  end
-
-  # is this a multisig script
-  def is_multisig?
-    return false  if @chunks.size < 4 || !@chunks[-2].is_a?(Bitcoin::Integer)
-    @chunks[-1] == OP_CHECKMULTISIG and get_multisig_pubkeys.all?{|c| c.is_a?(String) }
-  end
-
-  # is this an op_return script
-  def is_op_return?
-    @chunks[0] == OP_RETURN && @chunks.size <= 2
-  end
-
-  # is this a witness script
-  def is_witness?
-    @chunks.length == 2 && (0..16).include?(@chunks[0]) && @chunks[1].is_a?(String)
-  end
-
-  # is this a witness pubkey script
-  def is_witness_v0_keyhash?
-    is_witness? && @chunks[0] == 0 && @chunks[1].bytesize == 20
-  end
-
-  # is this a witness script hash
-  def is_witness_v0_scripthash?
-    is_witness? && @chunks[0] == 0 && @chunks[1].bytesize == 32
-  end
-
-  # Verify the script is only pushing data onto the stack
-  def is_push_only?(script_data=nil)
-    check_pushes(true, false, (script_data||@input_script))
-  end
-
-  # Make sure opcodes used to push data match their intended length ranges
-  def pushes_are_canonical?(script_data=nil)
-    check_pushes(false, true, (script_data||@raw))
-  end
-
-  def check_pushes(push_only=true, canonical_only=false, buf)
-    program = buf.unpack("C*")
-    until program.empty?
-      opcode = program.shift
-      if opcode > OP_16
-        return false if push_only
-        next
-      end
-      if opcode < OP_PUSHDATA1 && opcode > OP_0
-        # Could have used an OP_n code, rather than a 1-byte push.
-        return false if canonical_only && opcode == 1 && program[0] <= 16
-        program.shift(opcode)
-      end
-      if opcode == OP_PUSHDATA1
-        len = program.shift(1)[0]
-        # Could have used a normal n-byte push, rather than OP_PUSHDATA1.
-        return false if canonical_only && len < OP_PUSHDATA1
-        program.shift(len)
-      end
-      if opcode == OP_PUSHDATA2
-        len = program.shift(2).pack("C*").unpack("v")[0]
-        # Could have used an OP_PUSHDATA1.
-        return false if canonical_only && len <= 0xff
-        program.shift(len)
-      end
-      if opcode == OP_PUSHDATA4
-        len = program.shift(4).pack("C*").unpack("V")[0]
-        # Could have used an OP_PUSHDATA2.
-        return false if canonical_only && len <= 0xffff
-        program.shift(len)
-      end
-    end
-    true
-  rescue
-    # catch parsing errors
-    false
-  end
-
-  # get type of this tx
-  def type
-    if is_hash160?;                 :hash160
-    elsif is_pubkey?;               :pubkey
-    elsif is_multisig?;             :multisig
-    elsif is_p2sh?;                 :p2sh
-    elsif is_op_return?;            :op_return
-    elsif is_witness_v0_keyhash?;   :witness_v0_keyhash
-    elsif is_witness_v0_scripthash?;:witness_v0_scripthash
-    else;                           :unknown
-    end
-  end
-
-  # get the public key for this pubkey script
-  def get_pubkey
-    return @chunks[0].unpack("H*")[0] if @chunks.size == 1
-    is_pubkey? ? @chunks[0].unpack("H*")[0] : nil
-  end
-
-  # get the pubkey address for this pubkey script
-  def get_pubkey_address
-    Bitcoin.pubkey_to_address(get_pubkey)
-  end
-
-  # get the hash160 for this hash160 or pubkey script
-  def get_hash160
-    return @chunks[2..-3][0].unpack("H*")[0]  if is_hash160?
-    return @chunks[-2].unpack("H*")[0]        if is_p2sh?
-    return Bitcoin.hash160(get_pubkey)        if is_pubkey?
-    return @chunks[1].unpack("H*")[0]         if is_witness_v0_keyhash?
-    return @chunks[1].unpack("H*")[0]         if is_witness_v0_scripthash?
-  end
-
-  # get the hash160 address for this hash160 script
-  def get_hash160_address
-    Bitcoin.hash160_to_address(get_hash160)
-  end
-
-  # get the public keys for this multisig script
-  def get_multisig_pubkeys
-    1.upto(@chunks[-2] - 80).map{|i| @chunks[i] }
-  end
-
-  # get the pubkey addresses for this multisig script
-  def get_multisig_addresses
-    get_multisig_pubkeys.map{|pub|
-      begin
-        Bitcoin::Key.new(nil, pub.unpack("H*")[0]).addr
-      rescue OpenSSL::PKey::ECError, OpenSSL::PKey::EC::Point::Error
-      end
-    }
-  end
-
-  def get_p2sh_address
-    Bitcoin.hash160_to_p2sh_address(get_hash160)
-  end
-
-  # get the data possibly included in an OP_RETURN script
-  def get_op_return_data
-    return nil  unless is_op_return?
-    cast_to_string(@chunks[1]).unpack("H*")[0]  if @chunks[1]
-  end
-
-  # get all addresses this script corresponds to (if possible)
-  def get_addresses
-    return [get_pubkey_address]    if is_pubkey?
-    return [get_hash160_address]   if is_hash160?
-    return get_multisig_addresses  if is_multisig?
-    return [get_p2sh_address]      if is_p2sh?
-
-    if is_witness_v0_keyhash? || is_witness_v0_scripthash?
-      program_hex = chunks[1].unpack("H*").first
-      return [Bitcoin.encode_segwit_address(0, program_hex)]
-    end
-
-    []
-  end
-
-  # get single address, or first for multisig script
-  def get_address
-    addrs = get_addresses
-    addrs.is_a?(Array) ? addrs[0] : addrs
-  end
-
-  # generate pubkey tx script for given +pubkey+. returns a raw binary script of the form:
-  #  <pubkey> OP_CHECKSIG
-  def self.to_pubkey_script(pubkey)
-    pack_pushdata([pubkey].pack("H*")) + [ OP_CHECKSIG ].pack("C")
-  end
-
-  # generate hash160 tx for given +address+. returns a raw binary script of the form:
-  #  OP_DUP OP_HASH160 <hash160> OP_EQUALVERIFY OP_CHECKSIG
-  def self.to_hash160_script(hash160)
-    return nil  unless hash160
-    #  DUP   HASH160  length  hash160    EQUALVERIFY  CHECKSIG
-    [ ["76", "a9",    "14",   hash160,   "88",        "ac"].join ].pack("H*")
-  end
-
-  # generate p2sh output script for given +p2sh+ hash160. returns a raw binary script of the form:
-  #  OP_HASH160 <p2sh> OP_EQUAL
-  def self.to_p2sh_script(p2sh)
-    return nil  unless p2sh
-    # HASH160  length  hash  EQUAL
-    [ ["a9",   "14",   p2sh, "87"].join ].pack("H*")
-  end
-
-  # generate pay-to-witness output script for given +witness_version+ and
-  # +witness_program+. returns a raw binary script of the form:
-  # <witness_version> <witness_program>
-  def self.to_witness_script(witness_version, witness_program_hex)
-    return nil unless (0..16).include?(witness_version)
-    return nil unless witness_program_hex
-    version = witness_version != 0 ? 0x50 + witness_version : 0 # 0x50 for OP_1.. codes
-    [version].pack('C') + pack_pushdata(witness_program_hex.htb)
-  end
-
-  # generate p2wpkh tx for given +address+. returns a raw binary script of the form:
-  # 0 <hash160>
-  def self.to_witness_hash160_script(hash160)
-    return nil  unless hash160
-    to_witness_script(0, hash160)
-  end
-
-  # generate p2wsh output script for given +p2sh+ sha256. returns a raw binary script of the form:
-  # 0 <p2sh>
-  def self.to_witness_p2sh_script(p2sh)
-    return nil  unless p2sh
-    to_witness_script(0, p2sh)
-  end
-
-  # generate hash160 or p2sh output script, depending on the type of the given +address+.
-  # see #to_hash160_script and #to_p2sh_script.
-  def self.to_address_script(address)
-    hash160 = Bitcoin.hash160_from_address(address)
-    case Bitcoin.address_type(address)
-    when :hash160; to_hash160_script(hash160)
-    when :p2sh;    to_p2sh_script(hash160)
-    when :witness_v0_keyhash, :witness_v0_scripthash
-      witness_version, witness_program_hex = Bitcoin.decode_segwit_address(address)
-      to_witness_script(witness_version, witness_program_hex)
-    end
-  end
-
-  # generate multisig output script for given +pubkeys+, expecting +m+ signatures.
-  # returns a raw binary script of the form:
-  #  <m> <pubkey> [<pubkey> ...] <n_pubkeys> OP_CHECKMULTISIG
-  def self.to_multisig_script(m, *pubkeys)
-    raise "invalid m-of-n number" unless [m, pubkeys.size].all?{|i| (0..20).include?(i) }
-    raise "invalid m-of-n number" if pubkeys.size < m
-    pubs = pubkeys.map{|pk| pack_pushdata([pk].pack("H*")) }
-
-    m = m > 16 ?              pack_pushdata([m].pack("C"))              : [80 + m.to_i].pack("C")
-    n = pubkeys.size > 16 ?   pack_pushdata([pubkeys.size].pack("C"))   : [80 + pubs.size].pack("C")
-
-    [ m, *pubs, n, [OP_CHECKMULTISIG].pack("C")].join
-  end
-
-  # generate OP_RETURN output script with given data. returns a raw binary script of the form:
-  #  OP_RETURN <data>
-  def self.to_op_return_script(data = nil)
-    buf = [ OP_RETURN ].pack("C")
-    return buf unless data
-    return buf + pack_pushdata( [data].pack("H*") )
-  end
-
-  # generate input script sig spending a pubkey output with given +signature+ and +pubkey+.
-  # returns a raw binary script sig of the form:
-  #  <signature> [<pubkey>]
-  def self.to_pubkey_script_sig(signature, pubkey, hash_type = SIGHASH_TYPE[:all])
-    buf = pack_pushdata(signature + [hash_type].pack("C"))
-    return buf unless pubkey
-
-    expected_size = case pubkey[0]
-                    when "\x04"; 65
-                    when "\x02", "\x03"; 33
-                    end
-
-    raise "pubkey is not in binary form" if !expected_size || pubkey.bytesize != expected_size
-
-    return buf + pack_pushdata(pubkey)
-  end
-
-  # generate p2sh multisig output script for given +args+.
-  # returns the p2sh output script, and the redeem script needed to spend it.
-  # see #to_multisig_script for the redeem script, and #to_p2sh_script for the p2sh script.
-  def self.to_p2sh_multisig_script(*args)
-    redeem_script = to_multisig_script(*args)
-    p2sh_script = to_p2sh_script(Bitcoin.hash160(redeem_script.hth))
-    return p2sh_script, redeem_script
-  end
-
-  # alias for #to_pubkey_script_sig
-  def self.to_signature_pubkey_script(*a)
-    to_pubkey_script_sig(*a)
-  end
-
-  # generate input script sig spending a multisig output script.
-  # returns a raw binary script sig of the form:
-  #  OP_0 <sig> [<sig> ...]
-  def self.to_multisig_script_sig(*sigs)
-    hash_type = sigs.last.is_a?(Numeric) ? sigs.pop : SIGHASH_TYPE[:all]
-    partial_script = [OP_0].pack("C*")
-    sigs.reverse_each{ |sig| partial_script = add_sig_to_multisig_script_sig(sig, partial_script, hash_type) }
-    partial_script
-  end
-
-  # take a multisig script sig (or p2sh multisig script sig) and add
-  # another signature to it after the OP_0. Used to sign a tx by
-  # multiple parties. Signatures must be in the same order as the
-  # pubkeys in the output script being redeemed.
-  def self.add_sig_to_multisig_script_sig(sig, script_sig, hash_type = SIGHASH_TYPE[:all])
-    signature = sig + [hash_type].pack("C*")
-    offset = script_sig.empty? ? 0 : 1
-    script_sig.insert(offset, pack_pushdata(signature))
-  end
-
-  # generate input script sig spending a p2sh-multisig output script.
-  # returns a raw binary script sig of the form:
-  #  OP_0 <sig> [<sig> ...] <redeem_script>
-  def self.to_p2sh_multisig_script_sig(redeem_script, *sigs)
-    to_multisig_script_sig(*sigs.flatten) + pack_pushdata(redeem_script)
-  end
-
-  # Sort signatures in the given +script_sig+ according to the order of pubkeys in
-  # the redeem script. Also needs the +sig_hash+ to match signatures to pubkeys.
-  def self.sort_p2sh_multisig_signatures script_sig, sig_hash
-    script = new(script_sig)
-    redeem_script = new(script.chunks[-1])
-    pubkeys = redeem_script.get_multisig_pubkeys
-
-    # find the pubkey for each signature by trying to verify it
-    sigs = Hash[script.chunks[1...-1].map.with_index do |sig, idx|
-      pubkey = pubkeys.map {|key|
-        Bitcoin::Key.new(nil, key.hth).verify(sig_hash, sig) ? key : nil }.compact.first
-      raise "Key for signature ##{idx} not found in redeem script!"  unless pubkey
-      [pubkey, sig]
-    end]
-
-    [OP_0].pack("C*") + pubkeys.map {|k| sigs[k] ? pack_pushdata(sigs[k]) : nil }.join +
-      pack_pushdata(redeem_script.raw)
-  end
-
-  def get_signatures_required
-    return false unless is_multisig?
-    @chunks[0] - 80
-  end
-
-  def get_keys_provided
-    return false  unless is_multisig?
-    @chunks[-2] - 80
-  end
-
-  def codeseparator_count
-    @chunks.select{|c|c == Bitcoin::Script::OP_CODESEPARATOR}.length
-  end
-
-  # This matches CScript::GetSigOpCount(bool fAccurate)
-  # Note: this does not cover P2SH script which is to be unserialized
-  #       and checked explicitly when validating blocks.
-  def sigops_count_accurate(is_accurate)
-    count = 0
-    last_opcode = nil
-    @chunks.each do |chunk| # pushdate or opcode
-      if chunk == OP_CHECKSIG || chunk == OP_CHECKSIGVERIFY
-        count += 1
-      elsif chunk == OP_CHECKMULTISIG || chunk == OP_CHECKMULTISIGVERIFY
-        # Accurate mode counts exact number of pubkeys required (not signatures, but pubkeys!). Only used in P2SH scripts.
-        # Inaccurate mode counts every multisig as 20 signatures.
-        if is_accurate && last_opcode && last_opcode.is_a?(Bitcoin::Integer) && last_opcode >= OP_1 && last_opcode <= OP_16
-          count += ::Bitcoin::Script.decode_OP_N(last_opcode)
-        else
-          count += 20
+          case chunk
+          when *OPCODES_METHOD.keys
+            m = method(n = OPCODES_METHOD[chunk])
+            @debug << n.to_s.upcase
+            # invoke opcode method
+            case m.arity
+            when 0
+              m.call
+            when 1
+              m.call(check_callback)
+            when -2 # One fixed parameter, one optional
+              m.call(check_callback, opts)
+            else
+              puts "Bitcoin::Script: opcode #{name} method parameters invalid"
+            end
+          when *OP_2_16
+            @stack << OP_2_16.index(chunk) + 2
+            @debug << "OP_#{chunk - 80}"
+          else
+            name = OPCODES[chunk] || chunk
+            puts "Bitcoin::Script: opcode #{name} unkown or not implemented\n#{to_string.inspect}"
+            raise "opcode #{name} unkown or not implemented"
+          end
+        when String
+          if @do_exec
+            @debug << "PUSH DATA #{chunk.unpack('H*')[0]}"
+            @stack << chunk
+          else
+            @debug.pop
+          end
         end
       end
-      last_opcode = chunk
-    end
-    count
-  end
+      @debug << @stack.map do |i|
+        begin
+          i.unpack('H*')
+        rescue
+          i
+        end
+      end # if @do_exec
 
-  # This method applies to script_sig that is an input for p2sh output.
-  # Bitcoind has somewhat special way to return count for invalid input scripts:
-  # it returns 0 when the opcode can't be parsed or when it's over OP_16.
-  # Also, if the OP_{N} is used anywhere it's treated as 0-length data.
-  # See CScript::GetSigOpCount(const CScript& scriptSig) in bitcoind.
-  def sigops_count_for_p2sh
-    # This is a pay-to-script-hash scriptPubKey;
-    # get the last item that the scriptSig
-    # pushes onto the stack:
-
-    return 0 if @chunks.size == 0
-
-    data = nil
-    @chunks.each do |chunk|
-      case chunk
-      when Bitcoin::Integer
-        data = ""
-        return 0 if chunk > OP_16
-      when String
-        data = chunk
+      if @script_invalid
+        @stack << 0
+        @debug << 'INVALID TRANSACTION'
       end
-    end
-    return 0 if data == ""
 
-    ::Bitcoin::Script.new(data).sigops_count_accurate(true)
-  end
-
-  # Converts OP_{0,1,2,...,16} into 0, 1, 2, ..., 16.
-  # Returns nil for other opcodes.
-  def self.decode_OP_N(opcode)
-    if opcode == OP_0
-      return 0
+      @debug << 'RESULT'
+      return false if @stack.empty?
+      return false if cast_to_bool(@stack.pop) == false
+      true
     end
-    if opcode.is_a?(Bitcoin::Integer) && opcode >= OP_1 && opcode <= OP_16
-      return opcode - (OP_1 - 1);
-    else
+    # rubocop:enable Metrics/MethodLength, CyclomaticComplexity, PerceivedComplexity
+
+    def invalid
+      @script_invalid = true
       nil
     end
-  end
 
-
-
-
-  ## OPCODES
-
-  # Does nothing
-  def op_nop; end
-  def op_nop1; end
-  def op_nop2; end
-  def op_nop3; end
-  def op_nop4; end
-  def op_nop5; end
-  def op_nop6; end
-  def op_nop7; end
-  def op_nop8; end
-  def op_nop9; end
-  def op_nop10; end
-
-  # Duplicates the top stack item.
-  def op_dup
-    @stack << (@stack[-1].dup rescue @stack[-1])
-  end
-
-  # The input is hashed using SHA-256.
-  def op_sha256
-    buf = pop_string
-    @stack << Digest::SHA256.digest(buf)
-  end
-
-  # The input is hashed using SHA-1.
-  def op_sha1
-    buf = pop_string
-    @stack << Digest::SHA1.digest(buf)
-  end
-
-  # The input is hashed twice: first with SHA-256 and then with RIPEMD-160.
-  def op_hash160
-    buf = pop_string
-    @stack << Digest::RMD160.digest(Digest::SHA256.digest(buf))
-  end
-
-  # The input is hashed using RIPEMD-160.
-  def op_ripemd160
-    buf = pop_string
-    @stack << Digest::RMD160.digest(buf)
-  end
-
-  # The input is hashed two times with SHA-256.
-  def op_hash256
-    buf = pop_string
-    @stack << Digest::SHA256.digest(Digest::SHA256.digest(buf))
-  end
-
-  # Puts the input onto the top of the alt stack. Removes it from the main stack.
-  def op_toaltstack
-    @stack_alt << @stack.pop
-  end
-
-  # Puts the input onto the top of the main stack. Removes it from the alt stack.
-  def op_fromaltstack
-    @stack << @stack_alt.pop
-  end
-
-  # The item at the top of the stack is copied and inserted before the second-to-top item.
-  def op_tuck
-    @stack[-2..-1] = [ @stack[-1], *@stack[-2..-1] ]
-  end
-
-  # The top two items on the stack are swapped.
-  def op_swap
-    @stack[-2..-1] = @stack[-2..-1].reverse if @stack[-2]
-  end
-
-  # If both a and b are not 0, the output is 1. Otherwise 0.
-  def op_booland
-    a, b = pop_int(2)
-    @stack << (![a,b].any?{|n| n == 0 } ? 1 : 0)
-  end
-
-  # If a or b is not 0, the output is 1. Otherwise 0.
-  def op_boolor
-    a, b = pop_int(2)
-    @stack << ( (a != 0 || b != 0) ? 1 : 0 )
-  end
-
-  # a is added to b.
-  def op_add
-    a, b = pop_int(2)
-    @stack << a + b
-  end
-
-  # b is subtracted from a.
-  def op_sub
-    a, b = pop_int(2)
-    @stack << a - b
-  end
-
-  # Returns 1 if a is less than b, 0 otherwise.
-  def op_lessthan
-    a, b = pop_int(2)
-    @stack << (a < b ? 1 : 0)
-  end
-
-  # Returns 1 if a is less than or equal to b, 0 otherwise.
-  def op_lessthanorequal
-    a, b = pop_int(2)
-    @stack << (a <= b ? 1 : 0)
-  end
-
-  # Returns 1 if a is greater than b, 0 otherwise.
-  def op_greaterthan
-    a, b = pop_int(2)
-    @stack << (a > b ? 1 : 0)
-  end
-
-  # Returns 1 if a is greater than or equal to b, 0 otherwise.
-  def op_greaterthanorequal
-    a, b = pop_int(2)
-    @stack << (a >= b ? 1 : 0)
-  end
-
-  # If the input is 0 or 1, it is flipped. Otherwise the output will be 0.
-  def op_not
-    a = pop_int
-    @stack << (a == 0 ? 1 : 0)
-  end
-
-  def op_0notequal
-    a = pop_int
-    @stack << (a != 0 ? 1 : 0)
-  end
-
-  # The input is made positive.
-  def op_abs
-    a = pop_int
-    @stack << a.abs
-  end
-
-  # The input is divided by 2. Currently disabled.
-  def op_2div
-    a = pop_int
-    @stack << (a >> 1)
-  end
-
-  # The input is multiplied by 2. Currently disabled.
-  def op_2mul
-    a = pop_int
-    @stack << (a << 1)
-  end
-
-  # 1 is added to the input.
-  def op_1add
-    a = pop_int
-    @stack << (a + 1)
-  end
-
-  # 1 is subtracted from the input.
-  def op_1sub
-    a = pop_int
-    @stack << (a - 1)
-  end
-
-  # The sign of the input is flipped.
-  def op_negate
-    a = pop_int
-    @stack << -a
-  end
-
-  # Removes the top stack item.
-  def op_drop
-    @stack.pop
-  end
-
-  # Returns 1 if the inputs are exactly equal, 0 otherwise.
-  def op_equal
-    a, b = pop_string(2)
-    @stack << (a == b ? 1 : 0)
-  end
-
-  # Marks transaction as invalid if top stack value is not true. True is removed, but false is not.
-  def op_verify
-    res = pop_int
-    if cast_to_bool(res) == false
-      @stack << res
-      @script_invalid = true # raise 'transaction invalid' ?
-    else
-      @script_invalid = false
+    def self.drop_signatures(script_pubkey, drop_signatures)
+      script = new(script_pubkey).to_string.split(' ').delete_if do |c|
+        drop_signatures.include?(c)
+      end.join(' ')
+      binary_from_string(script)
     end
-  end
 
-  # Same as OP_EQUAL, but runs OP_VERIFY afterward.
-  def op_equalverify
-    op_equal; op_verify
-  end
+    # pay_to_script_hash: https://en.bitcoin.it/wiki/BIP_0016
+    #
+    # <sig> {<pub> OP_CHECKSIG} | OP_HASH160 <script_hash> OP_EQUAL
+    def pay_to_script_hash(block_timestamp, opts, check_callback)
+      return false if @chunks.size < 4
+      *rest, script, _, script_hash, _ = @chunks
+      script = rest.pop if script == OP_CODESEPARATOR
+      script = cast_to_string(script)
+      script_hash = cast_to_string(script_hash)
 
-  # An empty array of bytes is pushed onto the stack.
-  def op_0
-    @stack << "" # []
-  end
+      return false unless Bitcoin.hash160(script.unpack('H*')[0]) == script_hash.unpack('H*')[0]
+      return true if check_callback == :check
 
-  # The number 1 is pushed onto the stack. Same as OP_TRUE
-  def op_1
-    @stack << 1
-  end
-
-  # Returns the smaller of a and b.
-  def op_min
-    @stack << pop_int(2).min
-  end
-
-  # Returns the larger of a and b.
-  def op_max
-    @stack << pop_int(2).max
-  end
-
-  # Copies the pair of items two spaces back in the stack to the front.
-  def op_2over
-    @stack << @stack[-4]
-    @stack << @stack[-4]
-  end
-
-  # Swaps the top two pairs of items.
-  def op_2swap
-    p1 = @stack.pop(2)
-    p2 = @stack.pop(2)
-    @stack += p1 += p2
-  end
-
-  # If the input is true, duplicate it.
-  def op_ifdup
-    if cast_to_bool(@stack.last) == true
-      @stack << @stack.last
+      script = self.class.new(to_binary(rest) + script).inner_p2sh!(script)
+      result = script.run(block_timestamp, opts, &check_callback)
+      @debug = script.debug
+      # Set the execution stack to match the redeem script, so checks on stack contents at
+      # end of script execution validate correctly
+      @stack = script.stack
+      result
     end
-  end
 
-  # The number -1 is pushed onto the stack.
-  def op_1negate
-    @stack << -1
-  end
-
-  # Puts the number of stack items onto the stack.
-  def op_depth
-    @stack << @stack.size
-  end
-
-  # Returns 1 if x is within the specified range (left-inclusive), 0 otherwise.
-  def op_within
-    bn1, bn2, bn3 = pop_int(3)
-    @stack << ( (bn2 <= bn1 && bn1 < bn3) ? 1 : 0 )
-  end
-
-  # Returns 1 if the numbers are equal, 0 otherwise.
-  def op_numequal
-    a, b = pop_int(2)
-    @stack << (a == b ? 1 : 0)
-  end
-
-  # Returns 1 if the numbers are not equal, 0 otherwise.
-  def op_numnotequal
-    a, b = pop_int(2)
-    @stack << (a != b ? 1 : 0)
-  end
-
-  # Marks transaction as invalid.
-  def op_return
-    @script_invalid = true; nil
-  end
-
-  # Copies the second-to-top stack item to the top.
-  def op_over
-    item = @stack[-2]
-    @stack << item if item
-  end
-
-  # If the top stack value is not 0, the statements are executed. The top stack value is removed.
-  def op_if
-    value = false
-    if @do_exec
-      (invalid; return) if @stack.size < 1
-      value = cast_to_bool(pop_string) == false ? false : true
+    def inner_p2sh!(script = nil)
+      @inner_p2sh = true
+      @inner_script_code = script
+      self
     end
-    @exec_stack << value
-  end
 
-  # If the top stack value is 0, the statements are executed. The top stack value is removed.
-  def op_notif
-    value = false
-    if @do_exec
-      (invalid; return) if @stack.size < 1
-      value = cast_to_bool(pop_string) == false ? true : false
+    def inner_p2sh?
+      @inner_p2sh
     end
-    @exec_stack << value
-  end
 
-  # If the preceding OP_IF or OP_NOTIF or OP_ELSE was not executed then these statements are and if the preceding OP_IF or OP_NOTIF or OP_ELSE was executed then these statements are not.
-  def op_else
-    return if @exec_stack.empty?
-    @exec_stack[-1] = !@exec_stack[-1]
-  end
+    # get the inner p2sh script
+    def inner_p2sh_script
+      return nil if @chunks.size < 4
+      *rest, script, _, script_hash, _ = @chunks
+      script = rest.pop if script == OP_CODESEPARATOR
+      script = cast_to_string(script)
+      script_hash = cast_to_string(script_hash)
 
-  # Ends an if/else block.
-  def op_endif
-    return if @exec_stack.empty?
-    @exec_stack.pop
-  end
+      return nil unless Bitcoin.hash160(script.unpack('H*')[0]) == script_hash.unpack('H*')[0]
+      script
+    end
 
-  # The item n back in the stack is copied to the top.
-  def op_pick
-    return invalid if @stack.size < 2
-    pos = pop_int
-    return invalid if (pos < 0) || (pos >= @stack.size)
-    item = @stack[-(pos+1)]
-    @stack << item if item
-  end
+    # is this a :script_hash (pay-to-script-hash/p2sh) script?
+    # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+    def pay_to_script_hash?
+      @inner_p2sh ||= false
+      return false if @inner_p2sh
+      if @previous_output_script
+        chunks = Bitcoin::Script.new(@previous_output_script).chunks
+        chunks.size == 3 &&
+          chunks[-3] == OP_HASH160 &&
+          chunks[-2].is_a?(String) && chunks[-2].bytesize == 20 &&
+          chunks[-1] == OP_EQUAL
+      else
+        @chunks.size >= 3 &&
+          @chunks[-3] == OP_HASH160 &&
+          @chunks[-2].is_a?(String) && @chunks[-2].bytesize == 20 &&
+          @chunks[-1] == OP_EQUAL &&
+          # make sure the script_sig matches the p2sh hash from the pk_script (if there is one)
+          (@chunks.size > 3 ? pay_to_script_hash(nil, nil, :check) : true)
+      end
+    end
+    # rubocop:enable CyclomaticComplexity,PerceivedComplexity
 
-  # The fifth and sixth items back are moved to the top of the stack.
-  def op_2rot
-    return invalid if @stack.size < 6
-    @stack[-6..-1] = [ *@stack[-4..-1], *@stack[-6..-5] ]
-  end
+    def is_pay_to_script_hash? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_pay_to_script_hash?` is deprecated. ' \
+           'Use `pay_to_script_hash?` instead.'
+      pay_to_script_hash?
+    end
 
-  # The item n back in the stack is moved to the top.
-  def op_roll
-    return invalid if @stack.size < 2
-    pos = pop_int
-    return invalid if (pos < 0) || (pos >= @stack.size)
-    idx = -(pos+1)
-    item = @stack[idx]
-    if item
-      @stack.delete_at(idx)
+    alias is_p2sh? is_pay_to_script_hash?
+    alias p2sh? pay_to_script_hash?
+
+    # check if script is in one of the recognized standard formats
+    def standard?
+      pubkey? ||
+        hash160? ||
+        multisig? ||
+        p2sh? ||
+        op_return? ||
+        witness_v0_keyhash? ||
+        witness_v0_scripthash?
+    end
+
+    def is_standard? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_standard?` is deprecated. Use `standard?` instead.'
+      standard?
+    end
+
+    # is this a pubkey script
+    def pubkey?
+      return false if @chunks.size != 2
+      @chunks[1] == OP_CHECKSIG && @chunks[0] && @chunks[0].is_a?(String) && @chunks[0] != OP_RETURN
+    end
+
+    def is_pubkey? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_pubkey?` is deprecated. Use `pubkey?` instead.'
+      pubkey?
+    end
+
+    alias is_send_to_ip? is_pubkey?
+    alias send_to_ip? pubkey?
+
+    # is this a hash160 (address) script
+    def hash160?
+      return false if @chunks.size != 5
+      (@chunks[0..1] + @chunks[-2..-1]) ==
+        [OP_DUP, OP_HASH160, OP_EQUALVERIFY, OP_CHECKSIG] &&
+        @chunks[2].is_a?(String) && @chunks[2].bytesize == 20
+    end
+
+    def is_hash160? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_hash160?` is deprecated. Use `hash160?` instead.'
+      hash160?
+    end
+
+    # is this a multisig script
+    def multisig?
+      return false if @chunks.size < 4 || !@chunks[-2].is_a?(Bitcoin::Integer)
+      @chunks[-1] == OP_CHECKMULTISIG && get_multisig_pubkeys.all? { |c| c.is_a?(String) }
+    end
+
+    def is_multisig? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_multisig?` is deprecated. Use `multisig?` instead.'
+      multisig?
+    end
+
+    # is this an op_return script
+    def op_return?
+      @chunks[0] == OP_RETURN && @chunks.size <= 2
+    end
+
+    def is_op_return? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_op_return?` is deprecated. Use `op_return?` instead.'
+      op_return?
+    end
+
+    # is this a witness script
+    def witness?
+      @chunks.length == 2 && (0..16).cover?(@chunks[0]) && @chunks[1].is_a?(String)
+    end
+
+    def is_witness? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_witness?` is deprecated. Use `witness?` instead.'
+      witness?
+    end
+
+    # is this a witness pubkey script
+    def witness_v0_keyhash?
+      is_witness? && @chunks[0].zero? && @chunks[1].bytesize == 20
+    end
+
+    def is_witness_v0_keyhash? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_witness_v0_keyhash?` is deprecated. ' \
+           'Use `witness_v0_keyhash?` instead.'
+      witness_v0_keyhash?
+    end
+
+    # is this a witness script hash
+    def witness_v0_scripthash?
+      is_witness? && @chunks[0].zero? && @chunks[1].bytesize == 32
+    end
+
+    def is_witness_v0_scripthash? # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_witness_v0_scripthash?` is deprecated. ' \
+           'Use `witness_v0_scripthash?` instead.'
+      witness_v0_scripthash?
+    end
+
+    # Verify the script is only pushing data onto the stack
+    def push_only?(script_data = nil)
+      push_only = true
+      canonical_only = false
+      check_pushes(push_only, canonical_only, (script_data || @input_script))
+    end
+
+    def is_push_only?(script_data = nil) # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_push_only?` is deprecated. Use `push_only?` instead.'
+      push_only?(script_data)
+    end
+
+    # Make sure opcodes used to push data match their intended length ranges
+    def pushes_are_canonical?(script_data = nil)
+      push_only = false
+      canonical_only = true
+      check_pushes(push_only, canonical_only, (script_data || @raw))
+    end
+
+    # rubocop:disable CyclomaticComplexity,PerceivedComplexity, Style/OptionalArguments
+    def check_pushes(push_only = true, canonical_only = false, buf)
+      warn '[MODIFICATION] `Script.check_pushes` signature will be updated to ' \
+           'check_pushes(buf, push_only = true, canonical_only = false)'
+      program = buf.unpack('C*')
+      until program.empty?
+        opcode = program.shift
+        if opcode > OP_16
+          return false if push_only
+          next
+        end
+        if opcode < OP_PUSHDATA1 && opcode > OP_0
+          # Could have used an OP_n code, rather than a 1-byte push.
+          return false if canonical_only && opcode == 1 && program[0] <= 16
+          program.shift(opcode)
+        end
+        if opcode == OP_PUSHDATA1
+          len = program.shift(1)[0]
+          # Could have used a normal n-byte push, rather than OP_PUSHDATA1.
+          return false if canonical_only && len < OP_PUSHDATA1
+          program.shift(len)
+        end
+        if opcode == OP_PUSHDATA2
+          len = program.shift(2).pack('C*').unpack('v')[0]
+          # Could have used an OP_PUSHDATA1.
+          return false if canonical_only && len <= 0xff
+          program.shift(len)
+        end
+        if opcode == OP_PUSHDATA4 # rubocop:disable Style/Next
+          len = program.shift(4).pack('C*').unpack('V')[0]
+          # Could have used an OP_PUSHDATA2.
+          return false if canonical_only && len <= 0xffff
+          program.shift(len)
+        end
+      end
+      true
+    rescue
+      # catch parsing errors
+      false
+    end
+    # rubocop:enable CyclomaticComplexity,PerceivedComplexity, Style/OptionalArguments
+
+    # get type of this tx
+    def type
+      if is_hash160? then :hash160
+      elsif is_pubkey? then :pubkey
+      elsif is_multisig? then :multisig
+      elsif is_p2sh? then :p2sh
+      elsif is_op_return? then :op_return
+      elsif is_witness_v0_keyhash? then :witness_v0_keyhash
+      elsif is_witness_v0_scripthash? then :witness_v0_scripthash
+      else :unknown
+      end
+    end
+
+    # get the public key for this pubkey script
+    def get_pubkey # rubocop:disable Style/AccessorMethodName
+      return @chunks[0].unpack('H*')[0] if @chunks.size == 1
+      is_pubkey? ? @chunks[0].unpack('H*')[0] : nil
+    end
+
+    # get the pubkey address for this pubkey script
+    def get_pubkey_address # rubocop:disable Style/AccessorMethodName
+      Bitcoin.pubkey_to_address(get_pubkey)
+    end
+
+    # get the hash160 for this hash160 or pubkey script
+    def get_hash160 # rubocop:disable Style/AccessorMethodName
+      return @chunks[2..-3][0].unpack('H*')[0] if is_hash160?
+      return @chunks[-2].unpack('H*')[0] if is_p2sh?
+      return Bitcoin.hash160(get_pubkey) if is_pubkey?
+      return @chunks[1].unpack('H*')[0] if is_witness_v0_keyhash?
+      return @chunks[1].unpack('H*')[0] if is_witness_v0_scripthash?
+    end
+
+    # get the hash160 address for this hash160 script
+    def get_hash160_address # rubocop:disable Style/AccessorMethodName
+      Bitcoin.hash160_to_address(get_hash160)
+    end
+
+    # get the public keys for this multisig script
+    def get_multisig_pubkeys # rubocop:disable Style/AccessorMethodName
+      1.upto(@chunks[-2] - 80).map { |i| @chunks[i] }
+    end
+
+    # get the pubkey addresses for this multisig script
+    # rubocop:disable HandleExceptions
+    def get_multisig_addresses # rubocop:disable Style/AccessorMethodName
+      get_multisig_pubkeys
+      get_multisig_pubkeys.map do |pub|
+        begin
+          Bitcoin::Key.new(nil, pub.unpack('H*')[0]).addr
+        rescue OpenSSL::PKey::ECError, OpenSSL::PKey::EC::Point::Error
+        end
+      end
+    end
+    # rubocop:enable HandleExceptions
+
+    def get_p2sh_address # rubocop:disable Style/AccessorMethodName
+      Bitcoin.hash160_to_p2sh_address(get_hash160)
+    end
+
+    # get the data possibly included in an OP_RETURN script
+    def get_op_return_data # rubocop:disable Style/AccessorMethodName
+      return nil  unless is_op_return?
+      cast_to_string(@chunks[1]).unpack('H*')[0] if @chunks[1]
+    end
+
+    # get all addresses this script corresponds to (if possible)
+    def get_addresses # rubocop:disable Style/AccessorMethodName
+      return [get_pubkey_address] if is_pubkey?
+      return [get_hash160_address] if is_hash160?
+      return get_multisig_addresses if is_multisig?
+      return [get_p2sh_address] if is_p2sh?
+
+      if is_witness_v0_keyhash? || is_witness_v0_scripthash?
+        program_hex = chunks[1].unpack('H*').first
+        return [Bitcoin.encode_segwit_address(0, program_hex)]
+      end
+
+      []
+    end
+
+    # get single address, or first for multisig script
+    def get_address # rubocop:disable Style/AccessorMethodName
+      addrs = get_addresses
+      addrs.is_a?(Array) ? addrs[0] : addrs
+    end
+
+    # generate pubkey tx script for given +pubkey+. returns a raw binary script of the form:
+    #  <pubkey> OP_CHECKSIG
+    def self.to_pubkey_script(pubkey)
+      pack_pushdata([pubkey].pack('H*')) + [OP_CHECKSIG].pack('C')
+    end
+
+    # generate hash160 tx for given +address+. returns a raw binary script of the form:
+    #  OP_DUP OP_HASH160 <hash160> OP_EQUALVERIFY OP_CHECKSIG
+    def self.to_hash160_script(hash160)
+      return nil unless hash160
+      #  DUP   HASH160  length  hash160    EQUALVERIFY  CHECKSIG
+      [['76', 'a9', '14', hash160, '88', 'ac'].join].pack('H*')
+    end
+
+    # generate p2sh output script for given +p2sh+ hash160. returns a raw binary script of the form:
+    #  OP_HASH160 <p2sh> OP_EQUAL
+    def self.to_p2sh_script(p2sh)
+      return nil unless p2sh
+      # HASH160  length  hash  EQUAL
+      [['a9', '14', p2sh, '87'].join].pack('H*')
+    end
+
+    # generate pay-to-witness output script for given +witness_version+ and
+    # +witness_program+. returns a raw binary script of the form:
+    # <witness_version> <witness_program>
+    def self.to_witness_script(witness_version, witness_program_hex)
+      return nil unless (0..16).cover?(witness_version)
+      return nil unless witness_program_hex
+      version = witness_version != 0 ? 0x50 + witness_version : 0 # 0x50 for OP_1.. codes
+      [version].pack('C') + pack_pushdata(witness_program_hex.htb)
+    end
+
+    # generate p2wpkh tx for given +address+. returns a raw binary script of the form:
+    # 0 <hash160>
+    def self.to_witness_hash160_script(hash160)
+      return nil unless hash160
+      to_witness_script(0, hash160)
+    end
+
+    # generate p2wsh output script for given +p2sh+ sha256. returns a raw binary script of the form:
+    # 0 <p2sh>
+    def self.to_witness_p2sh_script(p2sh)
+      return nil unless p2sh
+      to_witness_script(0, p2sh)
+    end
+
+    # generate hash160 or p2sh output script, depending on the type of the given +address+.
+    # see #to_hash160_script and #to_p2sh_script.
+    def self.to_address_script(address)
+      hash160 = Bitcoin.hash160_from_address(address)
+      case Bitcoin.address_type(address)
+      when :hash160 then to_hash160_script(hash160)
+      when :p2sh then to_p2sh_script(hash160)
+      when :witness_v0_keyhash, :witness_v0_scripthash
+        witness_version, witness_program_hex = Bitcoin.decode_segwit_address(address)
+        to_witness_script(witness_version, witness_program_hex)
+      end
+    end
+
+    # generate multisig output script for given +pubkeys+, expecting +m+ signatures.
+    # returns a raw binary script of the form:
+    #  <m> <pubkey> [<pubkey> ...] <n_pubkeys> OP_CHECKMULTISIG
+    def self.to_multisig_script(m, *pubkeys)
+      raise 'invalid m-of-n number' unless [m, pubkeys.size].all? { |i| (0..20).cover?(i) }
+      raise 'invalid m-of-n number' if pubkeys.size < m
+      pubs = pubkeys.map { |pk| pack_pushdata([pk].pack('H*')) }
+
+      m = m > 16 ? pack_pushdata([m].pack('C')) : [80 + m.to_i].pack('C')
+      n = pubkeys.size > 16 ? pack_pushdata([pubkeys.size].pack('C')) : [80 + pubs.size].pack('C')
+
+      [m, *pubs, n, [OP_CHECKMULTISIG].pack('C')].join
+    end
+
+    # generate OP_RETURN output script with given data. returns a raw binary script of the form:
+    #  OP_RETURN <data>
+    def self.to_op_return_script(data = nil)
+      buf = [OP_RETURN].pack('C')
+      return buf unless data
+      buf + pack_pushdata([data].pack('H*'))
+    end
+
+    # generate input script sig spending a pubkey output with given +signature+ and +pubkey+.
+    # returns a raw binary script sig of the form:
+    #  <signature> [<pubkey>]
+    def self.to_pubkey_script_sig(signature, pubkey, hash_type = SIGHASH_TYPE[:all])
+      buf = pack_pushdata(signature + [hash_type].pack('C'))
+      return buf unless pubkey
+
+      expected_size = case pubkey[0]
+                      when "\x04" then 65
+                      when "\x02", "\x03" then 33
+                      end
+      raise 'pubkey is not in binary form' if !expected_size || pubkey.bytesize != expected_size
+
+      buf + pack_pushdata(pubkey)
+    end
+
+    # generate p2sh multisig output script for given +args+.
+    # returns the p2sh output script, and the redeem script needed to spend it.
+    # see #to_multisig_script for the redeem script, and #to_p2sh_script for the p2sh script.
+    def self.to_p2sh_multisig_script(*args)
+      redeem_script = to_multisig_script(*args)
+      p2sh_script = to_p2sh_script(Bitcoin.hash160(redeem_script.hth))
+      [p2sh_script, redeem_script]
+    end
+
+    # alias for #to_pubkey_script_sig
+    def self.to_signature_pubkey_script(*a)
+      to_pubkey_script_sig(*a)
+    end
+
+    # generate input script sig spending a multisig output script.
+    # returns a raw binary script sig of the form:
+    #  OP_0 <sig> [<sig> ...]
+    def self.to_multisig_script_sig(*sigs)
+      hash_type = sigs.last.is_a?(Numeric) ? sigs.pop : SIGHASH_TYPE[:all]
+      partial_script = [OP_0].pack('C*')
+      sigs.reverse_each do |sig|
+        partial_script = add_sig_to_multisig_script_sig(sig, partial_script, hash_type)
+      end
+      partial_script
+    end
+
+    # take a multisig script sig (or p2sh multisig script sig) and add
+    # another signature to it after the OP_0. Used to sign a tx by
+    # multiple parties. Signatures must be in the same order as the
+    # pubkeys in the output script being redeemed.
+    def self.add_sig_to_multisig_script_sig(sig, script_sig, hash_type = SIGHASH_TYPE[:all])
+      signature = sig + [hash_type].pack('C*')
+      offset = script_sig.empty? ? 0 : 1
+      script_sig.insert(offset, pack_pushdata(signature))
+    end
+
+    # generate input script sig spending a p2sh-multisig output script.
+    # returns a raw binary script sig of the form:
+    #  OP_0 <sig> [<sig> ...] <redeem_script>
+    def self.to_p2sh_multisig_script_sig(redeem_script, *sigs)
+      to_multisig_script_sig(*sigs.flatten) + pack_pushdata(redeem_script)
+    end
+
+    # Sort signatures in the given +script_sig+ according to the order of pubkeys in
+    # the redeem script. Also needs the +sig_hash+ to match signatures to pubkeys.
+    def self.sort_p2sh_multisig_signatures(script_sig, sig_hash)
+      script = new(script_sig)
+      redeem_script = new(script.chunks[-1])
+      pubkeys = redeem_script.get_multisig_pubkeys
+
+      # find the pubkey for each signature by trying to verify it
+      sigs = Hash[script.chunks[1...-1].map.with_index do |sig, idx|
+        pubkey = pubkeys.map do |key|
+          Bitcoin::Key.new(nil, key.hth).verify(sig_hash, sig) ? key : nil
+        end.compact.first
+        raise "Key for signature ##{idx} not found in redeem script!" unless pubkey
+        [pubkey, sig]
+      end]
+
+      [OP_0].pack('C*') + pubkeys.map { |k| sigs[k] ? pack_pushdata(sigs[k]) : nil }.join +
+        pack_pushdata(redeem_script.raw)
+    end
+
+    def get_signatures_required # rubocop:disable Style/AccessorMethodName
+      return false unless is_multisig?
+      @chunks[0] - 80
+    end
+
+    def get_keys_provided # rubocop:disable Style/AccessorMethodName
+      return false unless is_multisig?
+      @chunks[-2] - 80
+    end
+
+    def codeseparator_count
+      @chunks.select { |c| c == Bitcoin::Script::OP_CODESEPARATOR }.length
+    end
+
+    # This matches CScript::GetSigOpCount(bool fAccurate)
+    # Note: this does not cover P2SH script which is to be unserialized
+    #       and checked explicitly when validating blocks.
+    def sigops_count_accurate(is_accurate)
+      count = 0
+      last_opcode = nil
+      @chunks.each do |chunk| # pushdate or opcode
+        if [OP_CHECKSIG, OP_CHECKSIGVERIFY].include?(chunk)
+          count += 1
+        elsif [OP_CHECKMULTISIG, OP_CHECKMULTISIGVERIFY].include?(chunk)
+          # Accurate mode counts exact number of pubkeys required (not signatures, but pubkeys!).
+          # Only used in P2SH scripts. Inaccurate mode counts every multisig as 20 signatures.
+          count += if is_accurate &&
+                      last_opcode &&
+                      last_opcode.is_a?(Bitcoin::Integer) &&
+                      last_opcode >= OP_1 &&
+                      last_opcode <= OP_16
+                     ::Bitcoin::Script.decode_OP_N(last_opcode)
+                   else
+                     20
+                   end
+        end
+        last_opcode = chunk
+      end
+      count
+    end
+
+    # This method applies to script_sig that is an input for p2sh output.
+    # Bitcoind has somewhat special way to return count for invalid input scripts:
+    # it returns 0 when the opcode can't be parsed or when it's over OP_16.
+    # Also, if the OP_{N} is used anywhere it's treated as 0-length data.
+    # See CScript::GetSigOpCount(const CScript& scriptSig) in bitcoind.
+    def sigops_count_for_p2sh
+      # This is a pay-to-script-hash scriptPubKey;
+      # get the last item that the scriptSig
+      # pushes onto the stack:
+
+      return 0 if @chunks.empty?
+
+      data = nil
+      @chunks.each do |chunk|
+        case chunk
+        when Bitcoin::Integer
+          data = ''
+          return 0 if chunk > OP_16
+        when String
+          data = chunk
+        end
+      end
+      return 0 if data == ''
+
+      ::Bitcoin::Script.new(data).sigops_count_accurate(true)
+    end
+
+    # Converts OP_{0,1,2,...,16} into 0, 1, 2, ..., 16.
+    # Returns nil for other opcodes.
+    def self.decode_OP_N(opcode) # rubocop:disable Style/MethodName
+      return 0 if opcode == OP_0
+      return opcode - (OP_1 - 1) if opcode.is_a?(Bitcoin::Integer) && opcode >= OP_1 && opcode <= OP_16
+    end
+
+    ## OPCODES
+
+    # Does nothing
+    def op_nop; end
+
+    def op_nop1; end
+
+    def op_nop2; end
+
+    def op_nop3; end
+
+    def op_nop4; end
+
+    def op_nop5; end
+
+    def op_nop6; end
+
+    def op_nop7; end
+
+    def op_nop8; end
+
+    def op_nop9; end
+
+    def op_nop10; end
+
+    # Duplicates the top stack item.
+    def op_dup
+      stack_val = begin
+                    @stack[-1].dup
+                  rescue
+                    @stack[-1]
+                  end
+      @stack << stack_val
+    end
+
+    # The input is hashed using SHA-256.
+    def op_sha256
+      buf = pop_string
+      @stack << Digest::SHA256.digest(buf)
+    end
+
+    # The input is hashed using SHA-1.
+    def op_sha1
+      buf = pop_string
+      @stack << Digest::SHA1.digest(buf)
+    end
+
+    # The input is hashed twice: first with SHA-256 and then with RIPEMD-160.
+    def op_hash160
+      buf = pop_string
+      @stack << Digest::RMD160.digest(Digest::SHA256.digest(buf))
+    end
+
+    # The input is hashed using RIPEMD-160.
+    def op_ripemd160
+      buf = pop_string
+      @stack << Digest::RMD160.digest(buf)
+    end
+
+    # The input is hashed two times with SHA-256.
+    def op_hash256
+      buf = pop_string
+      @stack << Digest::SHA256.digest(Digest::SHA256.digest(buf))
+    end
+
+    # Puts the input onto the top of the alt stack. Removes it from the main stack.
+    def op_toaltstack
+      @stack_alt << @stack.pop
+    end
+
+    # Puts the input onto the top of the main stack. Removes it from the alt stack.
+    def op_fromaltstack
+      @stack << @stack_alt.pop
+    end
+
+    # The item at the top of the stack is copied and inserted before the second-to-top item.
+    def op_tuck
+      @stack[-2..-1] = [@stack[-1], *@stack[-2..-1]]
+    end
+
+    # The top two items on the stack are swapped.
+    def op_swap
+      @stack[-2..-1] = @stack[-2..-1].reverse if @stack[-2]
+    end
+
+    # If both a and b are not 0, the output is 1. Otherwise 0.
+    def op_booland
+      a, b = pop_int(2)
+      stack_val = [a, b].none?(&:zero?) ? 1 : 0
+      @stack << stack_val
+    end
+
+    # If a or b is not 0, the output is 1. Otherwise 0.
+    def op_boolor
+      a, b = pop_int(2)
+      stack_val = a != 0 || b != 0 ? 1 : 0
+      @stack << stack_val
+    end
+
+    # a is added to b.
+    def op_add
+      a, b = pop_int(2)
+      @stack << a + b
+    end
+
+    # b is subtracted from a.
+    def op_sub
+      a, b = pop_int(2)
+      @stack << a - b
+    end
+
+    # Returns 1 if a is less than b, 0 otherwise.
+    def op_lessthan
+      a, b = pop_int(2)
+      @stack << (a < b ? 1 : 0)
+    end
+
+    # Returns 1 if a is less than or equal to b, 0 otherwise.
+    def op_lessthanorequal
+      a, b = pop_int(2)
+      @stack << (a <= b ? 1 : 0)
+    end
+
+    # Returns 1 if a is greater than b, 0 otherwise.
+    def op_greaterthan
+      a, b = pop_int(2)
+      @stack << (a > b ? 1 : 0)
+    end
+
+    # Returns 1 if a is greater than or equal to b, 0 otherwise.
+    def op_greaterthanorequal
+      a, b = pop_int(2)
+      @stack << (a >= b ? 1 : 0)
+    end
+
+    # If the input is 0 or 1, it is flipped. Otherwise the output will be 0.
+    def op_not
+      a = pop_int
+      @stack << (a.zero? ? 1 : 0)
+    end
+
+    def op_0notequal
+      a = pop_int
+      @stack << (a != 0 ? 1 : 0)
+    end
+
+    # The input is made positive.
+    def op_abs
+      a = pop_int
+      @stack << a.abs
+    end
+
+    # The input is divided by 2. Currently disabled.
+    def op_2div
+      a = pop_int
+      @stack << (a >> 1)
+    end
+
+    # The input is multiplied by 2. Currently disabled.
+    def op_2mul
+      a = pop_int
+      @stack << (a << 1)
+    end
+
+    # 1 is added to the input.
+    def op_1add
+      a = pop_int
+      @stack << (a + 1)
+    end
+
+    # 1 is subtracted from the input.
+    def op_1sub
+      a = pop_int
+      @stack << (a - 1)
+    end
+
+    # The sign of the input is flipped.
+    def op_negate
+      a = pop_int
+      @stack << -a
+    end
+
+    # Removes the top stack item.
+    def op_drop
+      @stack.pop
+    end
+
+    # Returns 1 if the inputs are exactly equal, 0 otherwise.
+    def op_equal
+      a, b = pop_string(2)
+      @stack << (a == b ? 1 : 0)
+    end
+
+    # Marks transaction as invalid if top stack value is not true.
+    # True is removed, but false is not.
+    def op_verify
+      res = pop_int
+      if cast_to_bool(res) == false
+        @stack << res
+        @script_invalid = true # raise 'transaction invalid' ?
+      else
+        @script_invalid = false
+      end
+    end
+
+    # Same as OP_EQUAL, but runs OP_VERIFY afterward.
+    def op_equalverify
+      op_equal
+      op_verify
+    end
+
+    # An empty array of bytes is pushed onto the stack.
+    def op_0
+      @stack << '' # []
+    end
+
+    # The number 1 is pushed onto the stack. Same as OP_TRUE
+    def op_1
+      @stack << 1
+    end
+
+    # Returns the smaller of a and b.
+    def op_min
+      @stack << pop_int(2).min
+    end
+
+    # Returns the larger of a and b.
+    def op_max
+      @stack << pop_int(2).max
+    end
+
+    # Copies the pair of items two spaces back in the stack to the front.
+    def op_2over
+      @stack << @stack[-4]
+      @stack << @stack[-4]
+    end
+
+    # Swaps the top two pairs of items.
+    def op_2swap
+      p1 = @stack.pop(2)
+      p2 = @stack.pop(2)
+      @stack += p1 + p2
+    end
+
+    # If the input is true, duplicate it.
+    def op_ifdup
+      @stack << @stack.last if cast_to_bool(@stack.last) == true
+    end
+
+    # The number -1 is pushed onto the stack.
+    def op_1negate
+      @stack << -1
+    end
+
+    # Puts the number of stack items onto the stack.
+    def op_depth
+      @stack << @stack.size
+    end
+
+    # Returns 1 if x is within the specified range (left-inclusive), 0 otherwise.
+    def op_within
+      bn1, bn2, bn3 = pop_int(3)
+      stack_val = bn2 <= bn1 && bn1 < bn3 ? 1 : 0
+      @stack << stack_val
+    end
+
+    # Returns 1 if the numbers are equal, 0 otherwise.
+    def op_numequal
+      a, b = pop_int(2)
+      @stack << (a == b ? 1 : 0)
+    end
+
+    # Returns 1 if the numbers are not equal, 0 otherwise.
+    def op_numnotequal
+      a, b = pop_int(2)
+      @stack << (a != b ? 1 : 0)
+    end
+
+    # Marks transaction as invalid.
+    def op_return
+      @script_invalid = true
+      nil
+    end
+
+    # Copies the second-to-top stack item to the top.
+    def op_over
+      item = @stack[-2]
       @stack << item if item
     end
-  end
 
-  # The top three items on the stack are rotated to the left.
-  def op_rot
-    return if @stack.size < 3
-    @stack[-3..-1] = [ @stack[-2], @stack[-1], @stack[-3] ]
-  end
-
-  # Removes the top two stack items.
-  def op_2drop
-    @stack.pop(2)
-  end
-
-  # Duplicates the top two stack items.
-  def op_2dup
-    @stack.push(*@stack[-2..-1])
-  end
-
-  # Duplicates the top three stack items.
-  def op_3dup
-    @stack.push(*@stack[-3..-1])
-  end
-
-  # Removes the second-to-top stack item.
-  def op_nip
-    @stack.delete_at(-2)
-  end
-
-  # Returns the length of the input string.
-  def op_size
-    item = @stack[-1]
-    size = case item
-           when String; item.bytesize
-           when Numeric; OpenSSL::BN.new(item.to_s).to_mpi.size - 4
-           end
-    @stack << size
-  end
-
-  # Transaction is invalid unless occuring in an unexecuted OP_IF branch
-  def op_ver
-    invalid if @do_exec
-  end
-
-  def pop_int(count=nil)
-    return cast_to_bignum(@stack.pop) unless count
-    @stack.pop(count).map{|i| cast_to_bignum(i) }
-  end
-
-  def pop_string(count=nil)
-    return cast_to_string(@stack.pop) unless count
-    @stack.pop(count).map{|i| cast_to_string(i) }
-  end
-
-  def cast_to_bignum(buf)
-    return (invalid; 0) unless buf
-    case buf
-    when Numeric
-      invalid if OpenSSL::BN.new(buf.to_s).to_s(0).unpack("N")[0] > 4
-      buf
-    when String
-      invalid if buf.bytesize > 4
-      OpenSSL::BN.new([buf.bytesize].pack("N") + buf.reverse, 0).to_i
-    else; raise TypeError, 'cast_to_bignum: failed to cast: %s (%s)' % [buf, buf.class]
-    end
-  end
-
-  def cast_to_string(buf)
-    return (invalid; "") unless buf
-    case buf
-    when Numeric; OpenSSL::BN.new(buf.to_s).to_s(0)[4..-1].reverse
-    when String; buf;
-    else; raise TypeError, 'cast_to_string: failed to cast: %s (%s)' % [buf, buf.class]
-    end
-  end
-
-  def cast_to_bool(buf)
-    buf = cast_to_string(buf).unpack("C*")
-    size = buf.size
-    buf.each.with_index{|byte,index|
-      if byte != 0
-        # Can be negative zero
-        if (index == (size-1)) && byte == 0x80
-          return false
-        else
-          return true
+    # If the top stack value is not 0, the statements are executed. The top stack value is removed.
+    def op_if
+      value = false
+      if @do_exec
+        if @stack.empty?
+          invalid
+          return
         end
+        value = cast_to_bool(pop_string) == false ? false : true
       end
-    }
-    return false
-  end
-
-  # Same as OP_NUMEQUAL, but runs OP_VERIFY afterward.
-  def op_numequalverify
-    op_numequal; op_verify
-  end
-
-  # All of the signature checking words will only match signatures
-  # to the data after the most recently-executed OP_CODESEPARATOR.
-  def op_codeseparator
-    @codehash_start = @chunks.size - @chunks.reverse.index(OP_CODESEPARATOR)
-    @last_codeseparator_index = @chunk_last_index
-  end
-
-  def codehash_script(opcode)
-    # CScript scriptCode(pbegincodehash, pend);
-    script    = to_string(@chunks[(@codehash_start||0)...@chunks.size-@chunks.reverse.index(opcode)])
-    checkhash = Bitcoin.hash160(Bitcoin::Script.binary_from_string(script).unpack("H*")[0])
-    [script, checkhash]
-  end
-
-
-  # do a CHECKSIG operation on the current stack,
-  # asking +check_callback+ to do the actual signature verification.
-  # This is used by Protocol::Tx#verify_input_signature
-  def op_checksig(check_callback, opts={})
-    return invalid if @stack.size < 2
-    pubkey = cast_to_string(@stack.pop)
-    return (@stack << 0) unless Bitcoin::Script.check_pubkey_encoding?(pubkey, opts)
-    drop_sigs      = [ cast_to_string(@stack[-1]) ]
-
-    signature = cast_to_string(@stack.pop)
-    return invalid unless Bitcoin::Script.check_signature_encoding?(signature, opts)
-    return (@stack << 0) if signature == ""
-
-    sig, hash_type = parse_sig(signature)
-
-    subscript = sighash_subscript(drop_sigs, opts)
-
-    if check_callback == nil # for tests
-      @stack << 1
-    else # real signature check callback
-      @stack <<
-        ((check_callback.call(pubkey, sig, hash_type, subscript) == true) ? 1 : 0)
+      @exec_stack << value
     end
-  end
 
-  def sighash_subscript(drop_sigs, opts = {})
-    if opts[:fork_id]
-      drop_sigs.reject! do |signature|
-        if signature && signature.size > 0
-          _, hash_type = parse_sig(signature)
-          (hash_type&SIGHASH_TYPE[:forkid]) != 0
+    # If the top stack value is 0, the statements are executed. The top stack value is removed.
+    def op_notif
+      value = false
+      if @do_exec
+        if @stack.empty?
+          invalid
+          return
         end
+        value = cast_to_bool(pop_string) == false ? true : false
       end
+      @exec_stack << value
     end
 
-    if inner_p2sh? && @inner_script_code
-      ::Bitcoin::Script.new(@inner_script_code).to_binary_without_signatures(drop_sigs)
-    else
-      to_binary_without_signatures(drop_sigs)
+    # If the preceding OP_IF or OP_NOTIF or OP_ELSE was not executed then these statements are and
+    # if the preceding OP_IF or OP_NOTIF or OP_ELSE was executed then these statements are not.
+    def op_else
+      return if @exec_stack.empty?
+      @exec_stack[-1] = !@exec_stack[-1]
     end
-  end
 
-  # Same as OP_CHECKSIG, but OP_VERIFY is executed afterward.
-  def op_checksigverify(check_callback, opts={})
-    op_checksig(check_callback, opts)
-    op_verify
-  end
+    # Ends an if/else block.
+    def op_endif
+      return if @exec_stack.empty?
+      @exec_stack.pop
+    end
 
-  # do a CHECKMULTISIG operation on the current stack,
-  # asking +check_callback+ to do the actual signature verification.
-  #
-  # CHECKMULTISIG does a m-of-n signatures verification on scripts of the form:
-  #  0 <sig1> <sig2> | 2 <pub1> <pub2> 2 OP_CHECKMULTISIG
-  #  0 <sig1> <sig2> | 2 <pub1> <pub2> <pub3> 3 OP_CHECKMULTISIG
-  #  0 <sig1> <sig2> <sig3> | 3 <pub1> <pub2> <pub3> 3 OP_CHECKMULTISIG
-  #
-  # see https://en.bitcoin.it/wiki/BIP_0011 for details.
-  # see https://github.com/bitcoin/bitcoin/blob/master/src/script.cpp#L931
-  #
-  # TODO: validate signature order
-  # TODO: take global opcode count
-  def op_checkmultisig(check_callback, opts={})
-    return invalid if @stack.size < 1
-    n_pubkeys = pop_int
-    return invalid  unless (0..20).include?(n_pubkeys)
-    #return invalid  if (nOpCount += n_pubkeys) > 201
-    return invalid if @stack.size < n_pubkeys
-    pubkeys = pop_string(n_pubkeys)
+    # The item n back in the stack is copied to the top.
+    def op_pick
+      return invalid if @stack.size < 2
+      pos = pop_int
+      return invalid if (pos < 0) || (pos >= @stack.size)
+      item = @stack[-(pos + 1)]
+      @stack << item if item
+    end
 
-    return invalid if @stack.size < 1
-    n_sigs = pop_int
-    return invalid if n_sigs < 0 || n_sigs > n_pubkeys
-    return invalid if @stack.size < n_sigs
-    sigs = pop_string(n_sigs)
-    drop_sigs = sigs.dup
+    # The fifth and sixth items back are moved to the top of the stack.
+    def op_2rot
+      return invalid if @stack.size < 6
+      @stack[-6..-1] = [*@stack[-4..-1], *@stack[-6..-5]]
+    end
 
-    # Bitcoin-core removes an extra item from the stack
-    @stack.pop
+    # The item n back in the stack is moved to the top.
+    def op_roll
+      return invalid if @stack.size < 2
+      pos = pop_int
+      return invalid if (pos < 0) || (pos >= @stack.size)
+      idx = -(pos + 1)
+      item = @stack[idx]
+      @stack.delete_at(idx) if item
+      @stack << item if item
+    end
 
-    subscript = sighash_subscript(drop_sigs, opts)
+    # The top three items on the stack are rotated to the left.
+    def op_rot
+      return if @stack.size < 3
+      @stack[-3..-1] = [@stack[-2], @stack[-1], @stack[-3]]
+    end
 
-    success = true
-    while success && n_sigs > 0
-      sig, pub = sigs.pop, pubkeys.pop
-      return (@stack << 0) unless Bitcoin::Script.check_pubkey_encoding?(pub, opts)
-      return invalid unless Bitcoin::Script.check_signature_encoding?(sig, opts)
-      unless sig && sig.size > 0
-        success = false
-        break
+    # Removes the top two stack items.
+    def op_2drop
+      @stack.pop(2)
+    end
+
+    # Duplicates the top two stack items.
+    def op_2dup
+      @stack.push(*@stack[-2..-1])
+    end
+
+    # Duplicates the top three stack items.
+    def op_3dup
+      @stack.push(*@stack[-3..-1])
+    end
+
+    # Removes the second-to-top stack item.
+    def op_nip
+      @stack.delete_at(-2)
+    end
+
+    # Returns the length of the input string.
+    def op_size
+      item = @stack[-1]
+      size = case item
+             when String
+               item.bytesize
+             when Numeric
+               OpenSSL::BN.new(item.to_s).to_mpi.size - 4
+             end
+      @stack << size
+    end
+
+    # Transaction is invalid unless occuring in an unexecuted OP_IF branch
+    def op_ver
+      invalid if @do_exec
+    end
+
+    def pop_int(count = nil)
+      return cast_to_bignum(@stack.pop) unless count
+      @stack.pop(count).map { |i| cast_to_bignum(i) }
+    end
+
+    def pop_string(count = nil)
+      return cast_to_string(@stack.pop) unless count
+      @stack.pop(count).map { |i| cast_to_string(i) }
+    end
+
+    def cast_to_bignum(buf)
+      unless buf
+        invalid
+        return 0
       end
-      signature, hash_type = parse_sig(sig)
-      if pub.size > 0 && check_callback.call(pub, signature, hash_type, subscript)
-        n_sigs -= 1
+      case buf
+      when Numeric
+        invalid if OpenSSL::BN.new(buf.to_s).to_s(0).unpack('N')[0] > 4
+        buf
+      when String
+        invalid if buf.bytesize > 4
+        OpenSSL::BN.new([buf.bytesize].pack('N') + buf.reverse, 0).to_i
       else
-        sigs << sig
+        raise TypeError, format('cast_to_bignum: failed to cast: %s (%s)', buf, buf.class)
       end
-      n_pubkeys -= 1
-      success = false if n_sigs > n_pubkeys
     end
 
-    @stack << (success ? 1 : 0)
-  end
-
-  # Same as OP_CHECKMULTISIG, but OP_VERIFY is executed afterward.
-  def op_checkmultisigverify(check_callback, opts={})
-    op_checkmultisig(check_callback, opts)
-    op_verify
-  end
-
-  OPCODES_METHOD = Hash[*instance_methods.grep(/^op_/).map{|m|
-      [ (OPCODES.find{|k,v| v == m.to_s.upcase }.first rescue nil), m ]
-    }.flatten]
-  OPCODES_METHOD[0]  = :op_0
-  OPCODES_METHOD[81] = :op_1
-
-  def self.check_pubkey_encoding?(pubkey, opts={})
-    return false if opts[:verify_strictenc] && !is_compressed_or_uncompressed_pub_key?(pubkey)
-    true
-  end
-
-  def self.is_compressed_or_uncompressed_pub_key?(pubkey)
-    return false if pubkey.bytesize < 33 # "Non-canonical public key: too short"
-    case pubkey[0]
-    when "\x04"
-      return false if pubkey.bytesize != 65 # "Non-canonical public key: invalid length for uncompressed key"
-    when "\x02", "\x03"
-      return false if pubkey.bytesize != 33 # "Non-canonical public key: invalid length for compressed key"
-    else
-      return false # "Non-canonical public key: compressed nor uncompressed"
-    end
-    true
-  end
-
-  # Loosely matches CheckSignatureEncoding()
-  def self.check_signature_encoding?(sig, opts={})
-    return true  if sig.bytesize == 0
-    return false if (opts[:verify_dersig] || opts[:verify_low_s] || opts[:verify_strictenc]) and !is_der_signature?(sig)
-    return false if opts[:verify_low_s] && !is_low_der_signature?(sig)
-
-    if opts[:verify_strictenc]
-      return false unless is_defined_hashtype_signature?(sig)
-
-      hash_type = sig.unpack('C*')[-1]
-      uses_forkid = (hash_type&SIGHASH_TYPE[:forkid]) != 0
-      return false if opts[:fork_id] && !uses_forkid
-      return false if !opts[:fork_id] && uses_forkid
+    def cast_to_string(buf)
+      unless buf
+        invalid
+        return ''
+      end
+      case buf
+      when Numeric
+        OpenSSL::BN.new(buf.to_s).to_s(0)[4..-1].reverse
+      when String
+        buf
+      else
+        raise TypeError, format('cast_to_string: failed to cast: %s (%s)', buf, buf.class)
+      end
     end
 
-    true
-  end
-
-  # Loosely correlates with IsDERSignature() from interpreter.cpp
-  def self.is_der_signature?(sig)
-    return false if sig.bytesize < 9 # Non-canonical signature: too short
-    return false if sig.bytesize > 73 # Non-canonical signature: too long
-
-    s = sig.unpack("C*")
-
-    return false if s[0] != 0x30 # Non-canonical signature: wrong type
-    return false if s[1] != s.size-3 # Non-canonical signature: wrong length marker
-
-    length_r = s[3]
-    return false if (5 + length_r) >= s.size # Non-canonical signature: S length misplaced
-    length_s = s[5+length_r]
-    return false if (length_r + length_s + 7) != s.size # Non-canonical signature: R+S length mismatch
-
-    return false if s[2] != 0x02 # Non-canonical signature: R value type mismatch
-
-    return false if length_r == 0 # Non-canonical signature: R length is zero
-
-    r_val = s.slice(4, length_r)
-    return false if r_val[0] & 0x80 != 0 # Non-canonical signature: R value negative
-
-    return false if length_r > 1 && (r_val[0] == 0x00) && !(r_val[1] & 0x80 != 0) # Non-canonical signature: R value excessively padded
-
-    s_val = s.slice(6 + length_r, length_s)
-    return false if s[6 + length_r - 2] != 0x02 # Non-canonical signature: S value type mismatch
-
-    return false if length_s == 0 # Non-canonical signature: S length is zero
-    return false if (s_val[0] & 0x80) != 0 # Non-canonical signature: S value negative
-
-    return false if length_s > 1 && (s_val[0] == 0x00) && !(s_val[1] & 0x80) # Non-canonical signature: S value excessively padded
-
-    true
-  end
-
-  # Compares two arrays of bytes
-  def self.compare_big_endian(c1, c2)
-    c1, c2 = c1.dup, c2.dup # Clone the arrays
-
-    while c1.size > c2.size
-      return 1 if c1.shift > 0
+    def cast_to_bool(buf)
+      buf = cast_to_string(buf).unpack('C*')
+      size = buf.size
+      buf.each.with_index do |byte, index|
+        if byte != 0
+          # Can be negative zero
+          return !(index == (size - 1) && byte == 0x80)
+        end
+      end
+      false
     end
 
-    while c2.size > c1.size
-      return -1 if c2.shift > 0
+    # Same as OP_NUMEQUAL, but runs OP_VERIFY afterward.
+    def op_numequalverify
+      op_numequal
+      op_verify
     end
 
-    c1.size.times{|idx| return c1[idx] - c2[idx] if c1[idx] != c2[idx] }
-    0
+    # All of the signature checking words will only match signatures
+    # to the data after the most recently-executed OP_CODESEPARATOR.
+    def op_codeseparator
+      @codehash_start = @chunks.size - @chunks.reverse.index(OP_CODESEPARATOR)
+      @last_codeseparator_index = @chunk_last_index
+    end
+
+    def codehash_script(opcode)
+      # CScript scriptCode(pbegincodehash, pend);
+      script = to_string(
+        @chunks[(@codehash_start || 0)...@chunks.size - @chunks.reverse.index(opcode)]
+      )
+      checkhash = Bitcoin.hash160(Bitcoin::Script.binary_from_string(script).unpack('H*')[0])
+      [script, checkhash]
+    end
+
+    # do a CHECKSIG operation on the current stack,
+    # asking +check_callback+ to do the actual signature verification.
+    # This is used by Protocol::Tx#verify_input_signature
+    def op_checksig(check_callback, opts = {})
+      return invalid if @stack.size < 2
+      pubkey = cast_to_string(@stack.pop)
+      return (@stack << 0) unless Bitcoin::Script.check_pubkey_encoding?(pubkey, opts)
+      drop_sigs = [cast_to_string(@stack[-1])]
+
+      signature = cast_to_string(@stack.pop)
+      return invalid unless Bitcoin::Script.check_signature_encoding?(signature, opts)
+      return (@stack << 0) if signature == ''
+
+      sig, hash_type = parse_sig(signature)
+
+      subscript = sighash_subscript(drop_sigs, opts)
+
+      if check_callback.nil? # for tests
+        @stack << 1
+      else # real signature check callback
+        checksig = check_callback.call(pubkey, sig, hash_type, subscript) == true ? 1 : 0
+        @stack << checksig
+      end
+    end
+
+    def sighash_subscript(drop_sigs, opts = {})
+      if opts[:fork_id]
+        drop_sigs.reject! do |signature|
+          if signature && !signature.empty?
+            _, hash_type = parse_sig(signature)
+            (hash_type & SIGHASH_TYPE[:forkid]) != 0
+          end
+        end
+      end
+
+      if inner_p2sh? && @inner_script_code
+        ::Bitcoin::Script.new(@inner_script_code).to_binary_without_signatures(drop_sigs)
+      else
+        to_binary_without_signatures(drop_sigs)
+      end
+    end
+
+    # Same as OP_CHECKSIG, but OP_VERIFY is executed afterward.
+    def op_checksigverify(check_callback, opts = {})
+      op_checksig(check_callback, opts)
+      op_verify
+    end
+
+    # do a CHECKMULTISIG operation on the current stack,
+    # asking +check_callback+ to do the actual signature verification.
+    #
+    # CHECKMULTISIG does a m-of-n signatures verification on scripts of the form:
+    #  0 <sig1> <sig2> | 2 <pub1> <pub2> 2 OP_CHECKMULTISIG
+    #  0 <sig1> <sig2> | 2 <pub1> <pub2> <pub3> 3 OP_CHECKMULTISIG
+    #  0 <sig1> <sig2> <sig3> | 3 <pub1> <pub2> <pub3> 3 OP_CHECKMULTISIG
+    #
+    # see https://en.bitcoin.it/wiki/BIP_0011 for details.
+    # see https://github.com/bitcoin/bitcoin/blob/master/src/script.cpp#L931
+    #
+    # TODO: validate signature order
+    # TODO: take global opcode count
+    # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+    def op_checkmultisig(check_callback, opts = {})
+      return invalid if @stack.empty?
+      n_pubkeys = pop_int
+      return invalid unless (0..20).cover?(n_pubkeys)
+      # return invalid  if (nOpCount += n_pubkeys) > 201
+      return invalid if @stack.size < n_pubkeys
+      pubkeys = pop_string(n_pubkeys)
+
+      return invalid if @stack.empty?
+      n_sigs = pop_int
+      return invalid if n_sigs < 0 || n_sigs > n_pubkeys
+      return invalid if @stack.size < n_sigs
+      sigs = pop_string(n_sigs)
+      drop_sigs = sigs.dup
+
+      # Bitcoin-core removes an extra item from the stack
+      @stack.pop
+
+      subscript = sighash_subscript(drop_sigs, opts)
+
+      success = true
+      while success && n_sigs > 0
+        sig = sigs.pop
+        pub = pubkeys.pop
+        return (@stack << 0) unless Bitcoin::Script.check_pubkey_encoding?(pub, opts)
+        return invalid unless Bitcoin::Script.check_signature_encoding?(sig, opts)
+        unless sig && !sig.empty?
+          success = false
+          break
+        end
+        signature, hash_type = parse_sig(sig)
+        if !pub.empty? && check_callback.call(pub, signature, hash_type, subscript)
+          n_sigs -= 1
+        else
+          sigs << sig
+        end
+        n_pubkeys -= 1
+        success = false if n_sigs > n_pubkeys
+      end
+
+      @stack << (success ? 1 : 0)
+    end
+    # rubocop:enable CyclomaticComplexity,PerceivedComplexity
+
+    # Same as OP_CHECKMULTISIG, but OP_VERIFY is executed afterward.
+    def op_checkmultisigverify(check_callback, opts = {})
+      op_checkmultisig(check_callback, opts)
+      op_verify
+    end
+
+    OPCODES_METHOD = Hash[*instance_methods.grep(/^op_/).map do |m|
+      begin
+        [OPCODES.find { |_, v| v == m.to_s.upcase }.first, m]
+      rescue
+        [nil, m]
+      end
+    end.flatten]
+
+    OPCODES_METHOD[0]  = :op_0
+    OPCODES_METHOD[81] = :op_1
+
+    def self.check_pubkey_encoding?(pubkey, opts = {})
+      return false if opts[:verify_strictenc] && !is_compressed_or_uncompressed_pub_key?(pubkey)
+      true
+    end
+
+    def self.compressed_or_uncompressed_pub_key?(pubkey)
+      return false if pubkey.bytesize < 33 # "Non-canonical public key: too short"
+      case pubkey[0]
+      when "\x04"
+        # "Non-canonical public key: invalid length for uncompressed key"
+        return false if pubkey.bytesize != 65
+      when "\x02", "\x03"
+        # "Non-canonical public key: invalid length for compressed key"
+        return false if pubkey.bytesize != 33
+      else
+        return false # "Non-canonical public key: compressed nor uncompressed"
+      end
+      true
+    end
+
+    def self.is_compressed_or_uncompressed_pub_key?(pubkey) # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_compressed_or_uncompressed_pub_key?` is deprecated. ' \
+           'Use `compressed_or_uncompressed_pub_key?` instead.'
+      compressed_or_uncompressed_pub_key?(pubkey)
+    end
+
+    # Loosely matches CheckSignatureEncoding()
+    # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+    def self.check_signature_encoding?(sig, opts = {})
+      return true  if sig.bytesize.zero?
+      return false if (
+        opts[:verify_dersig] || opts[:verify_low_s] || opts[:verify_strictenc]
+      ) && !is_der_signature?(sig)
+      return false if opts[:verify_low_s] && !is_low_der_signature?(sig)
+
+      if opts[:verify_strictenc]
+        return false unless is_defined_hashtype_signature?(sig)
+
+        hash_type = sig.unpack('C*')[-1]
+        uses_forkid = (hash_type & SIGHASH_TYPE[:forkid]) != 0
+        return false if opts[:fork_id] && !uses_forkid
+        return false if !opts[:fork_id] && uses_forkid
+      end
+
+      true
+    end
+    # rubocop:enable CyclomaticComplexity,PerceivedComplexity
+
+    # Loosely correlates with IsDERSignature() from interpreter.cpp
+    # rubocop:disable CyclomaticComplexity,PerceivedComplexity
+    def self.der_signature?(sig)
+      return false if sig.bytesize < 9 # Non-canonical signature: too short
+      return false if sig.bytesize > 73 # Non-canonical signature: too long
+
+      s = sig.unpack('C*')
+
+      return false if s[0] != 0x30 # Non-canonical signature: wrong type
+      return false if s[1] != s.size - 3 # Non-canonical signature: wrong length marker
+
+      length_r = s[3]
+      return false if (5 + length_r) >= s.size # Non-canonical signature: S length misplaced
+      length_s = s[5 + length_r]
+
+      # Non-canonical signature: R+S length mismatch
+      return false if (length_r + length_s + 7) != s.size
+      return false if s[2] != 0x02 # Non-canonical signature: R value type mismatch
+
+      return false if length_r.zero? # Non-canonical signature: R length is zero
+
+      r_val = s.slice(4, length_r)
+      return false if r_val[0] & 0x80 != 0 # Non-canonical signature: R value negative
+
+      # Non-canonical signature: R value excessively padded
+      return false if length_r > 1 && r_val[0].zero? && (r_val[1] & 0x80).zero?
+
+      s_val = s.slice(6 + length_r, length_s)
+      return false if s[6 + length_r - 2] != 0x02 # Non-canonical signature: S value type mismatch
+
+      return false if length_s.zero? # Non-canonical signature: S length is zero
+      return false if (s_val[0] & 0x80) != 0 # Non-canonical signature: S value negative
+
+      # Non-canonical signature: S value excessively padded
+      return false if length_s > 1 && s_val[0].zero? && !(s_val[1] & 0x80)
+
+      true
+    end
+    # rubocop:enable CyclomaticComplexity,PerceivedComplexity
+
+    def self.is_der_signature?(sig) # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_der_signature?` is deprecated. ' \
+           'Use `der_signature?` instead.'
+      der_signature?(sig)
+    end
+
+    # Compares two arrays of bytes
+    def self.compare_big_endian(c1, c2)
+      # Clone the arrays
+      c1 = c1.dup
+      c2 = c2.dup
+
+      # rubocop:disable Style/WhileUntilModifier
+      while c1.size > c2.size
+        return 1 if c1.shift > 0
+      end
+
+      while c2.size > c1.size
+        return -1 if c2.shift > 0
+      end
+      # rubocop:enable Style/WhileUntilModifier
+
+      c1.size.times { |idx| return c1[idx] - c2[idx] if c1[idx] != c2[idx] }
+      0
+    end
+
+    # Loosely correlates with IsLowDERSignature() from interpreter.cpp
+    def self.low_der_signature?(sig)
+      s = sig.unpack('C*')
+
+      length_r = s[3]
+      length_s = s[5 + length_r]
+      s_val = s.slice(6 + length_r, length_s)
+
+      # If the S value is above the order of the curve divided by two, its
+      # complement modulo the order could have been used instead, which is
+      # one byte shorter when encoded correctly.
+      max_mod_half_order = [
+        0x7f, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff,
+        0x5d, 0x57, 0x6e, 0x73, 0x57, 0xa4, 0x50, 0x1d,
+        0xdf, 0xe9, 0x2f, 0x46, 0x68, 0x1b, 0x20, 0xa0
+      ]
+
+      compare_big_endian(s_val, [0]) > 0 &&
+        compare_big_endian(s_val, max_mod_half_order) <= 0
+    end
+
+    def self.is_low_der_signature?(sig) # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_low_der_signature?` is deprecated. ' \
+           'Use `low_der_signature?` instead.'
+      low_der_signature?(sig)
+    end
+
+    def self.defined_hashtype_signature?(sig)
+      return false if sig.empty?
+
+      s = sig.unpack('C*')
+      hash_type = s[-1] & ~(SIGHASH_TYPE[:anyonecanpay] | SIGHASH_TYPE[:forkid])
+
+      # Non-canonical signature: unknown hashtype byte
+      return false if hash_type < SIGHASH_TYPE[:all] || hash_type > SIGHASH_TYPE[:single]
+
+      true
+    end
+
+    def self.is_defined_hashtype_signature?(sig) # rubocop:disable Style/PredicateName
+      warn '[DEPRECATION] `Script.is_defined_hashtype_signature?` is deprecated. ' \
+           'Use `defined_hashtype_signature?` instead.'
+      defined_hashtype_signature?(sig)
+    end
+
+    private
+
+    def parse_sig(sig)
+      hash_type = sig[-1].unpack('C')[0]
+      sig = sig[0...-1]
+      [sig, hash_type]
+    end
   end
+end
 
-  # Loosely correlates with IsLowDERSignature() from interpreter.cpp
-  def self.is_low_der_signature?(sig)
-    s = sig.unpack("C*")
-
-    length_r = s[3]
-    length_s = s[5+length_r]
-    s_val = s.slice(6 + length_r, length_s)
-
-    # If the S value is above the order of the curve divided by two, its
-    # complement modulo the order could have been used instead, which is
-    # one byte shorter when encoded correctly.
-    max_mod_half_order = [
-      0x7f,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
-      0xff,0xff,0xff,0xff,0xff,0xff,0xff,0xff,
-      0x5d,0x57,0x6e,0x73,0x57,0xa4,0x50,0x1d,
-      0xdf,0xe9,0x2f,0x46,0x68,0x1b,0x20,0xa0]
-
-    compare_big_endian(s_val, [0]) > 0 &&
-      compare_big_endian(s_val, max_mod_half_order) <= 0
-  end
-
-  def self.is_defined_hashtype_signature?(sig)
-    return false if sig.empty?
-
-    s = sig.unpack("C*")
-    hash_type = s[-1] & (~(SIGHASH_TYPE[:anyonecanpay] | SIGHASH_TYPE[:forkid]))
-    return false if hash_type < SIGHASH_TYPE[:all]   ||  hash_type > SIGHASH_TYPE[:single] # Non-canonical signature: unknown hashtype byte
-
-    true
-  end
-
-
-  private
-
-  def parse_sig(sig)
-    hash_type = sig[-1].unpack("C")[0]
-    sig = sig[0...-1]
-    return sig, hash_type
-  end
+# Extend String for pushdata accessors
+class String
+  attr_accessor :bitcoin_pushdata
+  attr_accessor :bitcoin_pushdata_length
 end

--- a/lib/bitcoin/version.rb
+++ b/lib/bitcoin/version.rb
@@ -1,3 +1,3 @@
 module Bitcoin
-  VERSION = "0.0.18"
+  VERSION = '0.0.18'.freeze
 end


### PR DESCRIPTION
This is an incremental patch to get the bitcoin-ruby codebase conformed to a uniform code quality standard using rubocop.

Fixed files:
- `/lib/bitcoin/ext_key.rb`
- `/lib/bitcoin/key.rb`
- `/lib/bitcoin/litecoin.rb`
- `/lib/bitcoin/protocol.rb`
- `/lib/bitcoin/script.rb`
- `/lib/bitcoin/version.rb`


Updated Rubocop configs:
- `Metrics/BlockLength` maximum of 50
- `Metrics/ModuleLength` maximum of 500
- Excludes `lib/bitcoin/script.rb` from `Metrics/ClassLength`